### PR TITLE
Use s2i images

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1077,6 +1077,7 @@
     "github.com/stretchr/testify/require",
     "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",
+    "k8s.io/api/rbac/v1",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/labels",

--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,7 @@ image:https://img.shields.io/badge/zulip-join_chat-brightgreen.svg["Join Chat", 
 
 # WildFly Operator for Kubernetes/OpenShift
 
-The WildFly Operator for Kubernetes provides easy monitoring and configuration for Java applications deployed on http://wildfly.org[WildFly application server].
+The WildFly Operator for Kubernetes provides easy monitoring and configuration for Java applications deployed on http://wildfly.org[WildFly application server] using the https://github.com/openshift-s2i/s2i-wildfly[Source-to-Image (S2I) template for WildFly].
 
 Once installed, the WildFly Operator provides the following features:
 
@@ -59,7 +59,7 @@ spec:
 
 [NOTE]
 =====
-It is based on the application image https://quay.io/repository/jmesnil/wildfly-operator-quickstart[jmesnil/wildfly-operator-quickstart] that provides a simple Java Web application https://github.com/jmesnil/wildfly-operator-quickstart[wildfly-operator-quickstart] on top of WildFly 16.0.0.Final which returns the IP address of its host:
+It is based on the S2I application image https://quay.io/repository/jmesnil/wildfly-operator-quickstart[jmesnil/wildfly-operator-quickstart] that provides a simple Java Web application https://github.com/jmesnil/wildfly-operator-quickstart[wildfly-operator-quickstart] on top of WildFly 16.0.0.Final which returns the IP address of its host:
 
 [source,shell]
 ----
@@ -67,7 +67,7 @@ $ curl http://localhost:8080/
 {"ip":"172.17.0.3"}
 ----
 
-This simple application illustrates that successive calls will be load balanced across the various pods that runs the application
+This simple application illustrates that successive calls will be load balanced across the various pods that runs the application.
 =====
 
 [source,shell]

--- a/examples/clustering/README.adoc
+++ b/examples/clustering/README.adoc
@@ -1,8 +1,8 @@
 # Clustered application
 
-This example shows how to install and deploy a clustered WildFly application on OpenShift.
+This example shows how to install and deploy a clustered application built with S2I WildFly on Kubernetes or OpenShift.
 
-The application brings its own standalone configuration for WildFly that is configured to use JGroups and KUBE_PING to form the cluster.
+The application brings its own standalone configuration for WildFly that is configured to use JGroups and `KUBE_PING` to form the cluster.
 
 # Prerequisites
 
@@ -11,7 +11,7 @@ The application brings its own standalone configuration for WildFly that is conf
 
 # Deploy the application
 
-The application is named https://github.com/clusterbench/clusterbench[clusterbench] and will be deployed with a Docker image https://quay.io/repository/jmesnil/clusterbench[quay.io/jmesnil/clusterbench] that deploys the EE7 variant of the application on WildFly 16.
+The application is named https://github.com/clusterbench/clusterbench[clusterbench] and will be deployed with a Docker image built with https://github.com/openshift-s2i/s2i-wildfly[WildFly S2I] and published at https://quay.io/repository/jmesnil/clusterbench[quay.io/jmesnil/clusterbench] that deploys the EE7 variant of the application on WildFly 16.
 
 The application is defined in the https://github.com/wildfly/wildfly-operator/blob/master/examples/clustering/crds/clusterbenc.yaml[clusterbench.yaml file]:
 

--- a/examples/postgresql/README.adoc
+++ b/examples/postgresql/README.adoc
@@ -45,7 +45,7 @@ kind: WildFlyServer
 metadata:
   name: taskrs-app
 spec:
-  applicationImage: "quay.io/jfdenise/taskrs-app"
+  applicationImage: "quay.io/jmesnil/taskrs-app"
   size: 2
   env:
   - name: POSTGRESQL_SERVICE_HOST
@@ -69,7 +69,7 @@ spec:
         name: postgresql
 ----
 
-This custom resource will run the https://github.com/jfdenise/s2i-wildfly/tree/master/17.0/test/test-app-postgres[test-app-postgres] application from the https://quay.io/repository/jfdenise/taskrs-app[quay.io/jfdenise/taskrs-app] image.
+This custom resource will run the https://github.com/jfdenise/s2i-wildfly/tree/master/17.0/test/test-app-postgres[test-app-postgres] application from the https://quay.io/repository/jmesnil/taskrs-app[quay.io/jmesnil/taskrs-app] image that is using the https://github.com/openshift-s2i/s2i-wildfly[Source-to-Image (S2I) template for WildFly].
 
 The application requires the following Environment variables to configure its connection to PostgreSQL:
 
@@ -108,7 +108,7 @@ Metadata:
   Self Link:         /apis/wildfly.org/v1alpha1/namespaces/myproject/wildflyservers/taskrs-app
   UID:               14c880f3-54c7-11e9-9fb5-065375b5f883
 Spec:
-  Application Image:  quay.io/jfdenise/taskrs-app
+  Application Image:  quay.io/jmesnil/taskrs-app
   Env:
     Name:   POSTGRESQL_SERVICE_HOST
     Value:  postgresql

--- a/examples/postgresql/crds/taskrs-app.yaml
+++ b/examples/postgresql/crds/taskrs-app.yaml
@@ -3,7 +3,7 @@ kind: WildFlyServer
 metadata:
   name: taskrs-app
 spec:
-  applicationImage: "quay.io/jfdenise/taskrs-app@sha256:8eb374514d4bd504e699046fbea74082cb1e0575852e5a1a7fa03c1e78e20275"
+  applicationImage: "quay.io/jmesnil/taskrs-app"
   size: 2
   env:
   - name: POSTGRESQL_SERVICE_HOST


### PR DESCRIPTION
Update the operator to manage images built with WildFly S2I
(https://github.com/openshift-s2i/s2i-wildfly) instead of the vanilla
WildFly Docker image (https://www.github.com/jboss-dockerfiles/wildfly)

* rename the taskrs example to postgresql
* in the operator,set the jgroups.bind_addr system property to the Pod
  IP address to override the property set by the s2i image.