### PR TITLE
Use application image command for the Pods.

### DIFF
--- a/pkg/controller/wildflyserver/wildflyserver_controller.go
+++ b/pkg/controller/wildflyserver/wildflyserver_controller.go
@@ -278,13 +278,6 @@ func (r *ReconcileWildFlyServer) statefulSetForWildFly(w *wildflyv1alpha1.WildFl
 					Containers: []corev1.Container{{
 						Name:  w.Name,
 						Image: applicationImage,
-						Command: []string{
-							"/bin/bash",
-						},
-						// use $(hostname -i) to bind the public interface and JGroups to the pod IP address
-						Args: []string{
-							"-c", "/wildfly/bin/standalone.sh -b $(hostname -i) -bmanagement 0.0.0.0 -Djgroups.bind_addr=$(hostname -i) --debug 8787",
-						},
 						Ports: []corev1.ContainerPort{
 							{
 								ContainerPort: httpApplicationPort,


### PR DESCRIPTION
WildFly S2I command has been fixed to properly setup the public
interface as well as JGroups bind address.
The Operator no longer needs to overrides the application image command
(which corresponds to
https://github.com/openshift-s2i/s2i-wildfly/blob/master/16.0/s2i/bin/run).