### PR TITLE
[#4] Use standard annotations

### DIFF
--- a/deploy/crds/wildfly_v1alpha1_wildflyserver_crd.yaml
+++ b/deploy/crds/wildfly_v1alpha1_wildflyserver_crd.yaml
@@ -10,8 +10,6 @@ spec:
     plural: wildflyservers
     singular: wildflyserver
   scope: Namespaced
-  subresources:
-    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -82,8 +80,6 @@ spec:
                 - podIP
                 type: object
               type: array
-          required:
-          - pods
           type: object
   version: v1alpha1
   versions:

--- a/pkg/apis/wildfly/v1alpha1/wildflyserver_types.go
+++ b/pkg/apis/wildfly/v1alpha1/wildflyserver_types.go
@@ -39,7 +39,7 @@ type StorageSpec struct {
 // WildFlyServerStatus defines the observed state of WildFlyServer
 // +k8s:openapi-gen=true
 type WildFlyServerStatus struct {
-	Pods []PodStatus `json:"pods"`
+	Pods []PodStatus `json:"pods,omitempty"`
 }
 
 // PodStatus defines the observed state of pods running the WildFlyServer application

--- a/pkg/apis/wildfly/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/wildfly/v1alpha1/zz_generated.openapi.go
@@ -229,7 +229,6 @@ func schema_pkg_apis_wildfly_v1alpha1_WildFlyServerStatus(ref common.ReferenceCa
 						},
 					},
 				},
-				Required: []string{"pods"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/controller/wildflyserver/wildflyserver_controller.go
+++ b/pkg/controller/wildflyserver/wildflyserver_controller.go
@@ -315,7 +315,7 @@ func (r *ReconcileWildFlyServer) statefulSetForWildFly(w *wildflyv1alpha1.WildFl
 							},
 							{
 								Name:  "KUBERNETES_LABELS",
-								Value: "app=" + w.Name,
+								Value: labels.SelectorFromSet(ls).String(),
 							},
 						},
 					}},

--- a/test/framework/wildlfyserver.go
+++ b/test/framework/wildlfyserver.go
@@ -34,9 +34,8 @@ func MakeBasicWildFlyServer(ns, name, applicationImage string, size int32) *wild
 			APIVersion: "wildfly.org/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   ns,
-			Annotations: map[string]string{},
+			Name:      name,
+			Namespace: ns,
 		},
 		Spec: wildflyv1alpha1.WildFlyServerSpec{
 			ApplicationImage: applicationImage,


### PR DESCRIPTION
Use the same labels for JGroups' KUBERNETES_LABELS env var.

Issue: https://github.com/wildfly/wildfly-operator/issues/4