### PR TITLE
[#41] Externalize labels set by the operator

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,7 +2,9 @@ FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/wildfly-operator \
     USER_UID=1001 \
-    USER_NAME=wildfly-operator
+    USER_NAME=wildfly-operator \
+    LABEL_APP_MANAGED_BY=wildfly-operator \
+    LABEL_APP_RUNTIME=wildfly
 
 # install operator binary
 COPY build/_output/bin/wildfly-operator ${OPERATOR}

--- a/pkg/controller/wildflyserver/wildflyserver_controller.go
+++ b/pkg/controller/wildflyserver/wildflyserver_controller.go
@@ -3,6 +3,7 @@ package wildflyserver
 import (
 	"context"
 	"fmt"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -522,8 +523,8 @@ func getPodStatus(pods []corev1.Pod) (bool, []wildflyv1alpha1.PodStatus) {
 func labelsForWildFly(w *wildflyv1alpha1.WildFlyServer) map[string]string {
 	labels := make(map[string]string)
 	labels["app.kubernetes.io/name"] = w.Name
-	labels["app.kubernetes.io/managed-by"] = "wildfly-operator"
-	labels["app.openshift.io/runtime"] = "wildfly"
+	labels["app.kubernetes.io/managed-by"] = os.Getenv("LABEL_APP_MANAGED_BY")
+	labels["app.openshift.io/runtime"] = os.Getenv("LABEL_APP_RUNTIME")
 	if w.Labels != nil {
 		for labelKey, labelValue := range w.Labels {
 			labels[labelKey] = labelValue


### PR DESCRIPTION
Use the `LABEL_APP_MANAGED_BY` and `LABEL_APP_RUNTIME` to get the values
of the labels put by the operator on the Kubernetes resources.

Set their values in the operator Dockerfile to `wildfly-operator` and
`wildfly`.

This fixes #41.