### PR TITLE
Refactor build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ after_failure:
   - for log in $(docker ps -qa | xargs); do docker logs --tail 500 $log; done
 
 script:
-  - make build
+  - make image
+  - make setup
   - make test-e2e-16 KUBECONFIG=/tmp/openshift-dind-cluster/openshift/openshift.local.config/master/admin.kubeconfig
   - make test-e2e-17 KUBECONFIG=/tmp/openshift-dind-cluster/openshift/openshift.local.config/master/admin.kubeconfig

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+GOOS=${1-linux}
+BIN_DIR=${2-$(pwd)/build/_output/bin}
+mkdir -p ${BIN_DIR}
+PROJECT_NAME="wildfly-operator"
+REPO_PATH="github.com/wildfly/wildfly-operator"
+BUILD_PATH="${REPO_PATH}/cmd/manager"
+VERSION="$(git describe --tags --always --dirty)"
+GO_LDFLAGS="-X ${REPO_PATH}/version.Version=${VERSION}"
+echo "building ${PROJECT_NAME}..."
+GOOS=${GOOS} GOARCH=amd64 CGO_ENABLED=0 go build -o ${BIN_DIR}/${PROJECT_NAME} -ldflags "${GO_LDFLAGS}" $BUILD_PATH


### PR DESCRIPTION
* Remove requirement to install operator-sdk to build the project
* Build the project using `go build` directly
* Create the Docker image by executing `docker` directly

The operator-sdk is still required to:
* generate code when the WildFlyServer API changes
* run the e2e and scorecard tests