### PR TITLE
[#55] Fix WildFly directory location

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,7 @@
 FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/wildfly-operator \
+    JBOSS_HOME=/opt/jboss/wildfly \
     USER_UID=1001 \
     USER_NAME=wildfly-operator \
     LABEL_APP_MANAGED_BY=wildfly-operator \

--- a/pkg/controller/wildflyserver/wildflyserver_controller.go
+++ b/pkg/controller/wildflyserver/wildflyserver_controller.go
@@ -31,11 +31,12 @@ import (
 )
 
 var log = logf.Log.WithName("controller_wildflyserver")
+var jbossHome = os.Getenv("JBOSS_HOME")
+var standaloneServerDataDirPath = jbossHome + "/standalone/data"
 
 const (
-	httpApplicationPort         int32 = 8080
-	httpManagementPort          int32 = 9990
-	standaloneServerDataDirPath       = "/wildfly/standalone/data"
+	httpApplicationPort int32 = 8080
+	httpManagementPort  int32 = 9990
 )
 
 /**
@@ -434,7 +435,7 @@ func (r *ReconcileWildFlyServer) statefulSetForWildFly(w *wildflyv1alpha1.WildFl
 		})
 		statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts = append(statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
 			Name:      "standalone-config-volume",
-			MountPath: "/wildfly/standalone/configuration/standalone.xml",
+			MountPath: jbossHome + "/standalone/configuration/standalone.xml",
 			SubPath:   "standalone.xml",
 		})
 	}


### PR DESCRIPTION
use the JBOSS_HOME env var to set the server location to
/opt/jboss/wildfly/ (/wildfly was a symbolic link created for
convenience)

This fixes #55