### PR TITLE
[#60] Operator does not update on env removal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go v0.36.0 // indirect
 	github.com/Azure/go-autorest/autorest v0.3.0 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/RHsyseng/operator-utils v0.0.0-20190904181055-24b5b6380a3f
 	github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30 // indirect
 	github.com/coreos/prometheus-operator v0.26.0 // indirect
 	github.com/emicklei/go-restful v2.9.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tN
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/RHsyseng/operator-utils v0.0.0-20190904181055-24b5b6380a3f h1:M4w/F/4T7c5I1pbCcENdRbyXlj/sQSeVT1RGDC+IPew=
+github.com/RHsyseng/operator-utils v0.0.0-20190904181055-24b5b6380a3f/go.mod h1:E+hCtYz+9UsXfAGnRjX2LGuaa5gSGNKHCVTmGZR79vY=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/pkg/controller/wildflyserver/wildflyserver_controller_test.go
+++ b/pkg/controller/wildflyserver/wildflyserver_controller_test.go
@@ -6,6 +6,7 @@ import (
 
 	wildflyv1alpha1 "github.com/wildfly/wildfly-operator/pkg/apis/wildfly/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/stretchr/testify/assert"
@@ -80,4 +81,136 @@ func TestWildFlyServerControllerCreatesStatefulSet(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(replicas, *statefulSet.Spec.Replicas)
 	assert.Equal(applicationImage, statefulSet.Spec.Template.Spec.Containers[0].Image)
+}
+
+func TestEnvUpdate(t *testing.T) {
+	// Set the logger to development mode for verbose logs.
+	logf.SetLogger(logf.ZapLogger(true))
+	assert := assert.New(t)
+
+	initialEnv := &corev1.EnvVar{
+		Name:  "TEST_START",
+		Value: "INITIAL",
+	}
+
+	// A WildFlyServer resource with metadata and spec.
+	wildflyServer := &wildflyv1alpha1.WildFlyServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: wildflyv1alpha1.WildFlyServerSpec{
+			ApplicationImage: applicationImage,
+			Size:             replicas,
+			SessionAffinity:  sessionAffinity,
+			Env: []corev1.EnvVar{
+				*initialEnv,
+			},
+		},
+	}
+	// Objects to track in the fake client.
+	objs := []runtime.Object{
+		wildflyServer,
+	}
+
+	// Register operator types with the runtime scheme.
+	s := scheme.Scheme
+	s.AddKnownTypes(wildflyv1alpha1.SchemeGroupVersion, wildflyServer)
+	// Create a fake client to mock API calls.
+	cl := fake.NewFakeClient(objs...)
+	// Create a ReconcileWildFlyServer object with the scheme and fake client.
+	r := &ReconcileWildFlyServer{client: cl, scheme: s, isOpenShift: false}
+
+	// Mock request to simulate Reconcile() being called on an event for a
+	// watched resource .
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	res, err := r.Reconcile(req)
+	require.NoError(t, err)
+
+	// Check the result of reconciliation to make sure it has the desired state.
+	if !res.Requeue {
+		t.Error("reconcile did not requeue request as expected")
+	}
+
+	// Check if stateful set has been created and has the correct env var
+	statefulSet := &appsv1.StatefulSet{}
+	err = cl.Get(context.TODO(), req.NamespacedName, statefulSet)
+	require.NoError(t, err)
+	for _, env := range statefulSet.Spec.Template.Spec.Containers[0].Env {
+		if env.Name == "TEST_START" {
+			assert.Equal("INITIAL", env.Value)
+		}
+	}
+
+	// update the env in the WildFlyServerSpec
+	wildflyServer.Spec.Env[0].Value = "UPDATE"
+	cl.Update(context.TODO(), wildflyServer)
+	require.NoError(t, err)
+
+	res, err = r.Reconcile(req)
+	require.NoError(t, err)
+	if !res.Requeue {
+		t.Error("reconcile did not requeue request as expected")
+	}
+
+	// check that the statefulset env has been updated
+	err = cl.Get(context.TODO(), req.NamespacedName, statefulSet)
+	require.NoError(t, err)
+	for _, env := range statefulSet.Spec.Template.Spec.Containers[0].Env {
+		if env.Name == "TEST_START" {
+			assert.Equal("UPDATE", env.Value)
+		}
+	}
+
+	// remote the env from the WildFlyServerSpec
+	wildflyServer.Spec.Env = []corev1.EnvVar{}
+	cl.Update(context.TODO(), wildflyServer)
+	require.NoError(t, err)
+
+	res, err = r.Reconcile(req)
+	require.NoError(t, err)
+	if !res.Requeue {
+		t.Error("reconcile did not requeue request as expected")
+	}
+
+	// check that the statefulset env has been removed
+	err = cl.Get(context.TODO(), req.NamespacedName, statefulSet)
+	require.NoError(t, err)
+	for _, env := range statefulSet.Spec.Template.Spec.Containers[0].Env {
+		if env.Name == "TEST_START" {
+			t.Error("TEST_START env var must be removed")
+		}
+	}
+
+	// adding a new env to WildFlyServerSpec
+	addedEnv := &corev1.EnvVar{
+		Name:  "TEST_ADD",
+		Value: "ADD",
+	}
+	wildflyServer.Spec.Env = []corev1.EnvVar{
+		*addedEnv,
+	}
+
+	cl.Update(context.TODO(), wildflyServer)
+	require.NoError(t, err)
+
+	res, err = r.Reconcile(req)
+	require.NoError(t, err)
+	if !res.Requeue {
+		t.Error("reconcile did not requeue request as expected")
+	}
+
+	// check that the statefulset env has been added
+	err = cl.Get(context.TODO(), req.NamespacedName, statefulSet)
+	require.NoError(t, err)
+	for _, env := range statefulSet.Spec.Template.Spec.Containers[0].Env {
+		if env.Name == "TEST_ADD" {
+			assert.Equal("ADD", env.Value)
+		}
+	}
 }


### PR DESCRIPTION
Make a DeepEqual check against the statefulset spec env by taking into
account envs added by the operator (for clustering).
Any change to env in the WildFlyServerSpec (add, update, remove) will
trigger an update of the stateful set

Add module github.com/RHsyseng/operator-utils/pkg/utils/openshift to
determine when the operator is running on OpenShift (and skip the
route creation)

Add unit test to check the env update behaviour

This fixes #60