### PR TITLE
[#60] Operator does not update on env removal

### DIFF
--- a/pkg/controller/wildflyserver/wildflyserver_controller.go
+++ b/pkg/controller/wildflyserver/wildflyserver_controller.go
@@ -567,7 +567,8 @@ func envForClustering(labels string) []corev1.EnvVar {
 			Name: "KUBERNETES_NAMESPACE",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: "metadata.namespace",
+					APIVersion: "v1",
+					FieldPath:  "metadata.namespace",
 				},
 			},
 		},


### PR DESCRIPTION
* add the `APIVersion` field to the KUBERNETES_NAMESPACE env var

This relates to #60.