### PR TITLE
[#66] Changes to WildFlyServer Spec are not reflected in StatefulSet

### DIFF
--- a/pkg/controller/wildflyserver/wildflyserver_controller.go
+++ b/pkg/controller/wildflyserver/wildflyserver_controller.go
@@ -148,16 +148,11 @@ func (r *ReconcileWildFlyServer) Reconcile(request reconcile.Request) (reconcile
 		return reconcile.Result{}, err
 	}
 
-	// check if the stateful set is up to date with the WildFlyServerSpec
-	if checkUpdate(wildflyServer, foundStatefulSet) {
-		err = r.client.Update(context.TODO(), foundStatefulSet)
-		if err != nil {
-			reqLogger.Error(err, "Failed to update StatefulSet.", "StatefulSet.Namespace", foundStatefulSet.Namespace, "StatefulSet.Name", foundStatefulSet.Name)
-			return reconcile.Result{}, err
-		}
-
-		// Spec updated - return and requeue
-		return reconcile.Result{Requeue: true}, nil
+	mustReconcile, requeue, err := r.checkStatefulSet(wildflyServer, foundStatefulSet)
+	if mustReconcile {
+		return reconcile.Result{Requeue: requeue}, err
+	} else if err != nil {
+		return reconcile.Result{}, err
 	}
 
 	// Check if the loadbalancer already exists, if not create a new one
@@ -253,41 +248,66 @@ func (r *ReconcileWildFlyServer) Reconcile(request reconcile.Request) (reconcile
 	return reconcile.Result{}, nil
 }
 
-// check if the statefulset resource is up to date with the WildFlyServerSpec
-func checkUpdate(w *wildflyv1alpha1.WildFlyServer, statefuleSet *appsv1.StatefulSet) bool {
-	var update bool
-	// Ensure the application image is up to date
-	applicationImage := w.Spec.ApplicationImage
-	if statefuleSet.Spec.Template.Spec.Containers[0].Image != applicationImage {
-		log.Info("Updating application image to "+applicationImage, "StatefulSet.Namespace", statefuleSet.Namespace, "StatefulSet.Name", statefuleSet.Name)
-		statefuleSet.Spec.Template.Spec.Containers[0].Image = applicationImage
-		update = true
-	}
-	// Ensure the statefulset replicas is up to date
-	size := w.Spec.Size
-	if *statefuleSet.Spec.Replicas != size {
-		log.Info("Updating replica size to "+strconv.Itoa(int(size)), "StatefulSet.Namespace", statefuleSet.Namespace, "StatefulSet.Name", statefuleSet.Name)
-		statefuleSet.Spec.Replicas = &size
-		update = true
-	}
-	// Ensure the env variables are up to date
-	env := w.Spec.Env
-	// add the clustering envs that are added by the operator
-	env = append(env, envForClustering(labels.SelectorFromSet(labelsForWildFly(w)).String())...)
-	if !reflect.DeepEqual(statefuleSet.Spec.Template.Spec.Containers[0].Env, env) {
-		log.Info("Updating statefulset env", "StatefulSet.Namespace", statefuleSet.Namespace, "StatefulSet.Name", statefuleSet.Name, "Env", env)
-		statefuleSet.Spec.Template.Spec.Containers[0].Env = env
-		update = true
-	}
-	// Ensure the envFrom variables are up to date
-	envFrom := w.Spec.EnvFrom
-	if !reflect.DeepEqual(statefuleSet.Spec.Template.Spec.Containers[0].EnvFrom, envFrom) {
-		log.Info("Updating envFrom", "StatefulSet.Namespace", statefuleSet.Namespace, "StatefulSet.Name", statefuleSet.Name)
-		statefuleSet.Spec.Template.Spec.Containers[0].EnvFrom = envFrom
-		update = true
+// checkStatefulSet checks if the statefulset is up to date with the current WildFlyServerSpec.
+// it returns true if a reconcile result must be returned.
+// the 2nd boolean specifies whether the result must be required.
+// A non-nil error if an error happend while updating/deleting the statefulset.
+func (r *ReconcileWildFlyServer) checkStatefulSet(wildflyServer *wildflyv1alpha1.WildFlyServer, foundStatefulSet *appsv1.StatefulSet) (bool, bool, error) {
+	if generationStr, found := foundStatefulSet.Annotations["wildfly.org/wildfly-server-generation"]; found {
+		if generation, err := strconv.ParseInt(generationStr, 10, 64); err == nil {
+			// WildFlyServer spec has possibly changed, delete the statefulset
+			// so that a new one is created from the updated spec
+			if generation != wildflyServer.Generation {
+				statefulSet := r.statefulSetForWildFly(wildflyServer)
+				delete := false
+				// changes to VolumeClaimTemplates can not be updated and requires a delete/create of the statefulset
+				if len(statefulSet.Spec.VolumeClaimTemplates) > 0 {
+					if len(foundStatefulSet.Spec.VolumeClaimTemplates) == 0 {
+						// existing stateful set does not have a VCT
+						delete = true
+					} else {
+						foundVCT := foundStatefulSet.Spec.VolumeClaimTemplates[0]
+						vct := statefulSet.Spec.VolumeClaimTemplates[0]
+
+						if foundVCT.Name != vct.Name ||
+							!reflect.DeepEqual(foundVCT.Spec.AccessModes, vct.Spec.AccessModes) ||
+							!reflect.DeepEqual(foundVCT.Spec.Resources, vct.Spec.Resources) {
+							delete = true
+						}
+					}
+				} else {
+					if len(foundStatefulSet.Spec.VolumeClaimTemplates) != 0 {
+						// existing stateful set has a VCT while updated statefulset does not
+						delete = true
+					}
+				}
+
+				if delete {
+					// VolumeClaimTemplates has changed, the statefulset can not be updated and must be deleted
+					if err = r.client.Delete(context.TODO(), foundStatefulSet); err != nil {
+						log.Error(err, "Failed to Delete StatefulSet.", "StatefulSet.Namespace", foundStatefulSet.Namespace, "StatefulSet.Name", foundStatefulSet.Name)
+						return true, false, err
+					}
+					log.Info("Deleting StatefulSet that is not up to date with the WildFlyServer StorageSpec", "StatefulSet.Namespace", foundStatefulSet.Namespace, "StatefulSet.Name", foundStatefulSet.Name)
+					return true, true, nil
+				}
+
+				// all other changes are in the spec Template or Replicas and the statefulset can be updated
+				foundStatefulSet.Spec.Template = statefulSet.Spec.Template
+				foundStatefulSet.Spec.Replicas = statefulSet.Spec.Replicas
+				foundStatefulSet.Annotations["wildfly.org/wildfly-server-generation"] = strconv.FormatInt(wildflyServer.Generation, 10)
+				if err = r.client.Update(context.TODO(), foundStatefulSet); err != nil {
+					log.Error(err, "Failed to Update StatefulSet.", "StatefulSet.Namespace", foundStatefulSet.Namespace, "StatefulSet.Name", foundStatefulSet.Name)
+					return true, false, err
+				}
+				log.Info("Updating StatefulSet to be up to date with the WildFlyServer Spec", "StatefulSet.Namespace", foundStatefulSet.Namespace, "StatefulSet.Name", foundStatefulSet.Name)
+				return true, true, nil
+			}
+		}
 	}
 
-	return update
+	// no need to return from the loop
+	return false, false, nil
 }
 
 // matches checks if the envVar from the WildFlyServerSpec matches the same env var from the container.
@@ -310,6 +330,11 @@ func matches(container *v1.Container, envVar corev1.EnvVar) bool {
 // statefulSetForWildFly returns a wildfly StatefulSet object
 func (r *ReconcileWildFlyServer) statefulSetForWildFly(w *wildflyv1alpha1.WildFlyServer) *appsv1.StatefulSet {
 	ls := labelsForWildFly(w)
+	// track the generation number of the WildFlyServer that created the statefulset to ensure that the
+	// statefulset is always up to date with the WildFlyServerSpec
+	annotations := make(map[string]string)
+	annotations["wildfly.org/wildfly-server-generation"] = strconv.FormatInt(w.Generation, 10)
+
 	replicas := w.Spec.Size
 	applicationImage := w.Spec.ApplicationImage
 	volumeName := w.Name + "-volume"
@@ -320,9 +345,10 @@ func (r *ReconcileWildFlyServer) statefulSetForWildFly(w *wildflyv1alpha1.WildFl
 			Kind:       "StatefulSet",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      w.Name,
-			Namespace: w.Namespace,
-			Labels:    ls,
+			Name:        w.Name,
+			Namespace:   w.Namespace,
+			Labels:      ls,
+			Annotations: annotations,
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &replicas,

--- a/pkg/controller/wildflyserver/wildflyserver_controller_test.go
+++ b/pkg/controller/wildflyserver/wildflyserver_controller_test.go
@@ -149,7 +149,9 @@ func TestEnvUpdate(t *testing.T) {
 
 	// update the env in the WildFlyServerSpec
 	wildflyServer.Spec.Env[0].Value = "UPDATE"
-	cl.Update(context.TODO(), wildflyServer)
+	wildflyServer.SetGeneration(wildflyServer.GetGeneration() + 1)
+	err = cl.Update(context.TODO(), wildflyServer)
+	t.Logf("WildFlyServerSpec generation %d", wildflyServer.GetGeneration())
 	require.NoError(t, err)
 
 	res, err = r.Reconcile(req)
@@ -167,9 +169,11 @@ func TestEnvUpdate(t *testing.T) {
 		}
 	}
 
-	// remote the env from the WildFlyServerSpec
+	// remove the env from the WildFlyServerSpec
 	wildflyServer.Spec.Env = []corev1.EnvVar{}
-	cl.Update(context.TODO(), wildflyServer)
+	wildflyServer.SetGeneration(wildflyServer.GetGeneration() + 1)
+	err = cl.Update(context.TODO(), wildflyServer)
+	t.Logf("WildFlyServerSpec generation %d", wildflyServer.GetGeneration())
 	require.NoError(t, err)
 
 	res, err = r.Reconcile(req)
@@ -195,8 +199,9 @@ func TestEnvUpdate(t *testing.T) {
 	wildflyServer.Spec.Env = []corev1.EnvVar{
 		*addedEnv,
 	}
-
-	cl.Update(context.TODO(), wildflyServer)
+	wildflyServer.SetGeneration(wildflyServer.GetGeneration() + 1)
+	err = cl.Update(context.TODO(), wildflyServer)
+	t.Logf("WildFlyServerSpec generation %d", wildflyServer.GetGeneration())
 	require.NoError(t, err)
 
 	res, err = r.Reconcile(req)


### PR DESCRIPTION
Add `wildfly.org/wildfly-server-generation` annotation to the
statefulset to track the generation of the `WildFlyServer` that created
it.

If the generation does not match, update or delete the `statefulset` so
that its spec will be update according to the latest generation of the
`WildFlyServer`.

This fixes #66