### PR TITLE
[#70] statefulset links headless service instead of loadbalancer

### DIFF
--- a/pkg/controller/wildflyserver/wildflyserver_controller.go
+++ b/pkg/controller/wildflyserver/wildflyserver_controller.go
@@ -552,7 +552,7 @@ func (r *ReconcileWildFlyServer) statefulSetForWildFly(w *wildflyv1alpha1.WildFl
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas:            &replicas,
-			ServiceName:         loadBalancerServiceName(w),
+			ServiceName:         headlessServiceName(w),
 			PodManagementPolicy: appsv1.ParallelPodManagement,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: ls,


### PR DESCRIPTION
fixes #70 

StatefulSet has to be configured to link headless service. Otherwise it does not guarantee DNS identity for pods.