### PR TITLE
[issue72] pending container scaledown

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/sirupsen/logrus v1.4.1 // indirect
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.3.0
+	github.com/tevino/abool v0.0.0-20170917061928-9b9efcf221b5
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -270,6 +270,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
+github.com/tevino/abool v0.0.0-20170917061928-9b9efcf221b5 h1:hNna6Fi0eP1f2sMBe/rJicDmaHmoXGe1Ta84FPYHLuE=
+github.com/tevino/abool v0.0.0-20170917061928-9b9efcf221b5/go.mod h1:f1SCnEOt6sc3fOJfPQDRDzHOtSXuTtnz0ImG9kPRDV0=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.20.2 h1:NAfh7zF0/3/HqtMvJNZ/RFrSlCE6ZTlHmKfhL/Dm1Jk=

--- a/pkg/controller/util/go_utilities.go
+++ b/pkg/controller/util/go_utilities.go
@@ -72,3 +72,18 @@ func SortPodListByName(podList *corev1.PodList) *corev1.PodList {
 	})
 	return podList
 }
+
+// MapMerge merges the two maps together and returns the result.
+// If one of them is nil then is ommitted from the merged result
+// If both maps are null then an empty initialized map is returned
+// The second map rewrites data of the first map in the result if there are such
+func MapMerge(firstMap map[string]string, secondOverwritingMap map[string]string) map[string]string {
+	returnedMap := make(map[string]string)
+	for v, k := range firstMap {
+		returnedMap[v] = k
+	}
+	for v, k := range secondOverwritingMap {
+		returnedMap[v] = k
+	}
+	return returnedMap
+}

--- a/pkg/controller/util/remote_ops.go
+++ b/pkg/controller/util/remote_ops.go
@@ -27,6 +27,8 @@ var (
 	timestampFromLogLine = regexp.MustCompile(`^[0-9]{4}-[0-9]{2}-[0-9]{2}[^ ]+`)
 	// start of the time timestamp
 	startOfTheTimeTimestamp = time.Unix(0, 0)
+	// socket dial timeout
+	socketDialTimeout = 10 * time.Second
 )
 
 //ExecRemote executes a command inside the remote pod
@@ -87,7 +89,7 @@ func ExecRemote(pod *corev1.Pod, command string) (string, error) {
 func SocketConnect(hostname string, port int32, command string) (string, error) {
 	// connect to socket
 	toConnectTo := fmt.Sprintf("%v:%v", hostname, port)
-	conn, err := net.Dial("tcp", toConnectTo)
+	conn, err := net.DialTimeout("tcp", toConnectTo, socketDialTimeout)
 	if err != nil {
 		return "", fmt.Errorf("Cannot process TCP connection to %v, error: %v",
 			toConnectTo, err)

--- a/pkg/controller/util/wildfly_mgmt.go
+++ b/pkg/controller/util/wildfly_mgmt.go
@@ -22,8 +22,8 @@ var (
 	MgmtOpReload = ":reload()"
 	// MgmtOpRestart is a JBoss CLI command for restarting WFLY server
 	MgmtOpRestart = ":shutdown(restart=true)"
-	// MgmtOpTxnEnableRecoveryListener is a JBoss CLI command for enabling txn recovery listener
-	MgmtOpTxnEnableRecoveryListener = "/subsystem=transactions:write-attribute(name=recovery-listener, value=true)"
+	// MgmtOpTxnCheckRecoveryListener is a JBoss CLI command for enabling txn recovery listener
+	MgmtOpTxnCheckRecoveryListener = "/subsystem=transactions:read-attribute(name=recovery-listener)"
 	// MgmtOpTxnProbe is a JBoss CLI command for probing transaction log store
 	MgmtOpTxnProbe = "/subsystem=transactions/log-store=log-store:probe()"
 	// MgmtOpTxnRead is a JBoss CLI command for reading transaction log store

--- a/pkg/controller/util/wildfly_mgmt.go
+++ b/pkg/controller/util/wildfly_mgmt.go
@@ -202,7 +202,7 @@ func ExecuteOpAndWaitForServerBeingReady(mgmtOp string, pod *corev1.Pod, jbossHo
 		return false, fmt.Errorf("Cannot run operation '%v' at application container for down pod %s, error: %v", mgmtOp, podName, err)
 	}
 	if !IsMgmtOutcomeSuccesful(jsonResult) {
-		return false, fmt.Errorf("Not succefully runnin management operation '%v' for pod %s. JSON output: %v",
+		return false, fmt.Errorf("Not succefully running management operation '%v' for pod %s. JSON output: %v",
 			mgmtOp, podName, jsonResult)
 	}
 	for serverStateCheckCounter := 0; err != nil && serverStateCheckCounter < reloadRetryCount; serverStateCheckCounter++ {

--- a/pkg/controller/wildflyserver/wildflyserver_controller.go
+++ b/pkg/controller/wildflyserver/wildflyserver_controller.go
@@ -1032,6 +1032,10 @@ func (r *ReconcileWildFlyServer) checkRecovery(reqLogger logr.Logger, scaleDownP
 	reqLogger.Info("Executing recovery scan at "+scaleDownPodName, "Pod IP", scaleDownPodIP, "Recovery port", scaleDownPodRecoveryPort)
 	_, err = wildflyutil.SocketConnect(scaleDownPodIP, scaleDownPodRecoveryPort, txnRecoveryScanCommand)
 	if err != nil {
+		delete(scaleDownPod.Annotations, markerRecoveryPort)
+		if err := r.client.Update(context.TODO(), scaleDownPod); err != nil {
+			reqLogger.Info("Cannot update scaledown pod %v while resetting the annotation map to %v", scaleDownPodName, scaleDownPod.Annotations)
+		}
 		return false, "", fmt.Errorf("Failed to run transaction recovery scan for scaling down pod %v. "+
 			"Please, verify the pod log file. Error: %v", scaleDownPodName, err)
 	}

--- a/pkg/controller/wildflyserver/wildflyserver_controller_test.go
+++ b/pkg/controller/wildflyserver/wildflyserver_controller_test.go
@@ -3,11 +3,13 @@ package wildflyserver
 import (
 	"context"
 	"testing"
+	"time"
 
 	wildflyv1alpha1 "github.com/wildfly/wildfly-operator/pkg/apis/wildfly/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -223,4 +225,116 @@ func TestEnvUpdate(t *testing.T) {
 			assert.Equal("ADD", env.Value)
 		}
 	}
+}
+
+func TestWildFlyServerControllerScaleDown(t *testing.T) {
+	// Set the logger to development mode for verbose logs.
+	logf.SetLogger(logf.ZapLogger(true))
+	assert := assert.New(t)
+	expectedReplicaSize := int32(1)
+
+	// A WildFlyServer resource with metadata and spec.
+	wildflyServer := &wildflyv1alpha1.WildFlyServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: wildflyv1alpha1.WildFlyServerSpec{
+			ApplicationImage: applicationImage,
+			Size:             expectedReplicaSize,
+			SessionAffinity:  sessionAffinity,
+		},
+	}
+	// Objects to track in the fake client.
+	objs := []runtime.Object{
+		wildflyServer,
+	}
+
+	// Register operator types with the runtime scheme.
+	s := scheme.Scheme
+	s.AddKnownTypes(wildflyv1alpha1.SchemeGroupVersion, wildflyServer)
+	// Create a fake client to mock API calls.
+	cl := fake.NewFakeClient(objs...)
+	// Create a ReconcileWildFlyServer object with the scheme and fake client.
+	r := &ReconcileWildFlyServer{client: cl, scheme: s, recorder: eventRecorderMock{}, isOpenShift: false, isWildFlyFinalizer: true}
+	// Mock request to simulate Reconcile() being called on an event for a
+	// watched resource .
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	// Statefulset will be created
+	_, err := r.Reconcile(req)
+	require.NoError(t, err)
+
+	// Check if stateful set has been created and has the correct size.
+	statefulSet := &appsv1.StatefulSet{}
+	err = cl.Get(context.TODO(), req.NamespacedName, statefulSet)
+	require.NoError(t, err)
+	assert.Equal(expectedReplicaSize, *statefulSet.Spec.Replicas)
+	assert.Equal(applicationImage, statefulSet.Spec.Template.Spec.Containers[0].Image)
+
+	// Finalizer will be added
+	_, err = r.Reconcile(req)
+	require.NoError(t, err)
+	err = cl.Get(context.TODO(), req.NamespacedName, wildflyServer)
+	require.NoError(t, err)
+	assert.Equal(1, len(wildflyServer.GetFinalizers()))
+	assert.Equal("finalizer.wildfly.org", wildflyServer.GetFinalizers()[0])
+	// Operator correctly setup the StatefulSet replica thus move on and create the Pod that the operator waits for
+	//   StatefulSet won't do this here for us thus manual creation is needed
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "ScaleDownTestPod", Namespace: wildflyServer.Namespace, Labels: LabelsForWildFly(wildflyServer)},
+		TypeMeta:   metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}}
+	err = cl.Create(context.TODO(), pod)
+	require.NoError(t, err)
+
+	log.Info("Waiting for WildflyServer is updated to the state where WildflyServer.Status.Pods refers the Pod created by the test")
+	err = wait.Poll(100*time.Millisecond, 5*time.Second, func() (done bool, err error) {
+		_, err = r.Reconcile(req)
+		require.NoError(t, err)
+
+		podList, err := GetPodsForWildFly(r, wildflyServer)
+		err2 := cl.Get(context.TODO(), req.NamespacedName, wildflyServer)
+		if err == nil && len(podList.Items) == int(expectedReplicaSize) &&
+			err2 == nil && len(wildflyServer.Status.Pods) == int(expectedReplicaSize) {
+			return true, nil
+		}
+		return false, nil
+	})
+
+	log.Info("WildFly server was reconciliated to the state the pod status corresponds with namespace. Let's scale it down.",
+		"WildflyServer", wildflyServer)
+	assert.Equal(int(expectedReplicaSize), len(wildflyServer.Status.Pods))
+	assert.Equal(wildflyv1alpha1.PodStateActive, wildflyServer.Status.Pods[0].State)
+	wildflyServer.Spec.Size = 0
+	err = cl.Update(context.TODO(), wildflyServer)
+
+	// Reconcile for the scale down - updating the pod labels
+	_, err = r.Reconcile(req)
+	require.NoError(t, err)
+	// Pod label has to be changed to not being active for service
+	podList, err := GetPodsForWildFly(r, wildflyServer)
+	require.NoError(t, err)
+	assert.Equal(int(expectedReplicaSize), len(podList.Items))
+	assert.Equal("disabled", podList.Items[0].GetLabels()["wildfly.org/operated-by-loadbalancer"])
+
+	// Reconcile for the scale down - updating the pod state at the wildflyserver CR
+	_, err = r.Reconcile(req) // error could be returned here as the scaledown was not sucessful here
+	err = cl.Get(context.TODO(), req.NamespacedName, wildflyServer)
+	require.NoError(t, err)
+	assert.Equal(wildflyv1alpha1.PodStateScalingDownRecoveryInvestigation, wildflyServer.Status.Pods[0].State)
+}
+
+type eventRecorderMock struct {
+}
+
+func (rm eventRecorderMock) Event(object runtime.Object, eventtype, reason, message string) {}
+func (rm eventRecorderMock) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+}
+func (rm eventRecorderMock) PastEventf(object runtime.Object, timestamp metav1.Time, eventtype, reason, messageFmt string, args ...interface{}) {
+}
+func (rm eventRecorderMock) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
 }


### PR DESCRIPTION
fixes #72 

Fixing the issues found for scaledown processing.
The scaledown could hang in some cases, a panic exception could be got when pod annotations were not ready to be used and a wrong error was reported to the user during processing the finalizer.