### PR TITLE
[#76] process socket binding read effetively + fixing tx-recovery-listnener checking condition + making the socket timeout configurable

### DIFF
--- a/pkg/controller/util/go_utilities.go
+++ b/pkg/controller/util/go_utilities.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 	"sort"
@@ -113,4 +114,52 @@ func GetEnvAsInt(key string, fallbackInteger int64) int64 {
 func GetEnvAsDuration(key string, fallbackDurationAmount int64, durationType time.Duration) time.Duration {
 	valueAsInt := GetEnvAsInt(key, fallbackDurationAmount)
 	return time.Duration(valueAsInt) * durationType
+}
+
+// ConvertToInt takes interface type and tries to convert it to int32
+func ConvertToInt(intf interface{}) (int32, error) {
+	switch v := intf.(type) {
+	case int32:
+		return v, nil
+	case int:
+		return int32(v), nil
+	case float64:
+		return int32(int(v)), nil
+	case float32:
+		return int32(v), nil
+	case string:
+		i, err := strconv.ParseInt(v, 10, 32)
+		if err != nil {
+			return 0, err
+		}
+		return int32(i), nil
+	case nil:
+		return 0, fmt.Errorf("The passed value is nil and cannot be converted to int32")
+	default:
+		return 0, fmt.Errorf("Un-expected type of passed value %v, actual type is %T", intf, intf)
+	}
+}
+
+// ConvertToString takes interface type and tries to convert it to string
+func ConvertToString(intf interface{}) (string, error) {
+	switch vv := intf.(type) {
+	case string:
+		return vv, nil
+	case int:
+		return strconv.Itoa(vv), nil
+	case int32:
+		return strconv.Itoa(int(vv)), nil
+	case int64:
+		return strconv.Itoa(int(vv)), nil
+	case float64:
+		return fmt.Sprintf("%f", vv), nil
+	case float32:
+		return fmt.Sprintf("%f", vv), nil
+	case bool:
+		return strconv.FormatBool(vv), nil
+	case nil:
+		return "", fmt.Errorf("The passed value is nil and cannot be converted to int32")
+	default:
+		return "", fmt.Errorf("Un-expected type of passed value %v, actual type is %T", intf, intf)
+	}
 }

--- a/pkg/controller/util/go_utilities.go
+++ b/pkg/controller/util/go_utilities.go
@@ -1,9 +1,11 @@
 package util
 
 import (
+	"os"
 	"regexp"
 	"sort"
 	"strconv"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -86,4 +88,29 @@ func MapMerge(firstMap map[string]string, secondOverwritingMap map[string]string
 		returnedMap[v] = k
 	}
 	return returnedMap
+}
+
+// GetEnvAsInt returns defined environment variable as an integer
+//  or default value is returned if the env var is not configured
+func GetEnvAsInt(key string, fallbackInteger int64) int64 {
+	valueStr, ok := os.LookupEnv(key)
+	if ok {
+		valueInt, err := strconv.ParseInt(valueStr, 10, 64)
+		if err == nil {
+			return valueInt
+		}
+	}
+	return fallbackInteger
+}
+
+// GetEnvAsDuration returns defined environment variable as duration
+//  while it expects the environment variable contains the number defined in duration type
+//  defined as a third parameter. The result will be returned as duration.
+//  If env variable is not found then the default value as duration is returned (defined by the duration type)
+//  e.g. call 'GetEnvAsDuration("TIMEOUT", 10, time.Second)' means
+//   search for the TIMEOUT env variable and the value is expected being defined in seconds,
+//   if the env var is not found then returns duration of 10 seconds
+func GetEnvAsDuration(key string, fallbackDurationAmount int64, durationType time.Duration) time.Duration {
+	valueAsInt := GetEnvAsInt(key, fallbackDurationAmount)
+	return time.Duration(valueAsInt) * durationType
 }

--- a/pkg/controller/util/remote_ops.go
+++ b/pkg/controller/util/remote_ops.go
@@ -28,7 +28,7 @@ var (
 	// start of the time timestamp
 	startOfTheTimeTimestamp = time.Unix(0, 0)
 	// socket dial timeout
-	socketDialTimeout = 10 * time.Second
+	socketDialTimeout = GetEnvAsDuration("SOCKET_DIAL_TIMEOUT", 10, time.Second)
 )
 
 //ExecRemote executes a command inside the remote pod

--- a/pkg/controller/wildflyserver/wildflyserver_controller.go
+++ b/pkg/controller/wildflyserver/wildflyserver_controller.go
@@ -210,7 +210,7 @@ func (r *ReconcileWildFlyServer) Reconcile(request reconcile.Request) (reconcile
 	}
 	// Processing recovery on pods which are planned to be removed because of scale down is in progress now
 	mustReconcile, err := r.processTransactionRecoveryScaleDown(reqLogger, wildflyServer, int(numberOfPodsToScaleDown), podList)
-	if mustReconcile { // server state was updated (or/and some erro could happen), we need to reconcile
+	if mustReconcile { // server state was updated (or/and some error could happen), we need to reconcile
 		return reconcile.Result{Requeue: true}, err
 	}
 	if err != nil {

--- a/pkg/controller/wildflyserver/wildflyserver_controller_test.go
+++ b/pkg/controller/wildflyserver/wildflyserver_controller_test.go
@@ -24,11 +24,11 @@ import (
 )
 
 var (
-	name                   = "myapp"
-	namespace              = "mynamespace"
-	replicas         int32 = 0
-	applicationImage       = "my-app-image"
-	sessionAffinity        = true
+	name             = "myapp"
+	namespace        = "mynamespace"
+	replicas         = int32(0)
+	applicationImage = "my-app-image"
+	sessionAffinity  = true
 )
 
 func TestWildFlyServerControllerCreatesStatefulSet(t *testing.T) {


### PR DESCRIPTION
fixes #76 
fixes #83

The tx-recovery-listener was wrongly checked if it's defined or not. Because of that the scaledown recovery processing was not working properly.

This adds an environmental variable for operator to define socket timeout for transaction scan.