### PR TITLE
[#70] statefulset headless service second

### DIFF
--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -60,7 +60,7 @@ func NewStatefulSet(w *wildflyv1alpha1.WildFlyServer, labels map[string]string) 
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas:            &replicas,
-			ServiceName:         services.LoadBalancerServiceName(w),
+			ServiceName:         services.HeadlessServiceName(w),
 			PodManagementPolicy: appsv1.ParallelPodManagement,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,


### PR DESCRIPTION
fixes #70 

The statefulset has to be bound to headless service otherwise it does not guarantees the DNS stability.