### PR TITLE
[#33] Support scale subresources

### DIFF
--- a/deploy/crds/quickstart-cr.yaml
+++ b/deploy/crds/quickstart-cr.yaml
@@ -4,10 +4,4 @@ metadata:
   name: quickstart
 spec:
   applicationImage: "quay.io/wildfly-quickstarts/wildfly-operator-quickstart:17.0"
-  size: 2
-  storage:
-    volumeClaimTemplate:
-      spec:
-        resources:
-          requests:
-            storage: 3Gi
+  replicas: 2

--- a/deploy/crds/wildfly_v1alpha1_wildflyserver_crd.yaml
+++ b/deploy/crds/wildfly_v1alpha1_wildflyserver_crd.yaml
@@ -3,465 +3,133 @@ kind: CustomResourceDefinition
 metadata:
   name: wildflyservers.wildfly.org
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.replicas
+    name: Replicas
+    type: integer
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: wildfly.org
   names:
     kind: WildFlyServer
     listKind: WildFlyServerList
     plural: wildflyservers
-    singular: wildflyserver
     shortNames:
     - wfly
-  scope: ""
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: WildFlyServer is the Schema for the wildflyservers API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: WildFlyServerSpec defines the desired state of WildFlyServer
-            properties:
-              applicationImage:
-                description: ApplicationImage is the name of the application image
-                  to be deployed
-                type: string
-              disableHTTPRoute:
-                description: DisableHTTPRoute disables the creation a route to the
-                  HTTP port of the application service (false if omitted)
-                type: boolean
-              env:
-                description: Env contains environment variables for the containers
-                  running the WildFlyServer application
-                items:
-                  description: EnvVar represents an environment variable present in
-                    a Container.
-                  properties:
-                    name:
-                      description: Name of the environment variable. Must be a C_IDENTIFIER.
-                      type: string
-                    value:
-                      description: 'Variable references $(VAR_NAME) are expanded using
-                        the previous defined environment variables in the container
-                        and any service environment variables. If a variable cannot
-                        be resolved, the reference in the input string will be unchanged.
-                        The $(VAR_NAME) syntax can be escaped with a double $$, ie:
-                        $$(VAR_NAME). Escaped references will never be expanded, regardless
-                        of whether the variable exists or not. Defaults to "".'
-                      type: string
-                    valueFrom:
-                      description: Source for the environment variable's value. Cannot
-                        be used if value is not empty.
-                      properties:
-                        configMapKeyRef:
-                          description: Selects a key of a ConfigMap.
-                          properties:
-                            key:
-                              description: The key to select.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                            optional:
-                              description: Specify whether the ConfigMap or it's key
-                                must be defined
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                        fieldRef:
-                          description: 'Selects a field of the pod: supports metadata.name,
-                            metadata.namespace, metadata.labels, metadata.annotations,
-                            spec.nodeName, spec.serviceAccountName, status.hostIP,
-                            status.podIP.'
-                          properties:
-                            apiVersion:
-                              description: Version of the schema the FieldPath is
-                                written in terms of, defaults to "v1".
-                              type: string
-                            fieldPath:
-                              description: Path of the field to select in the specified
-                                API version.
-                              type: string
-                          required:
-                          - fieldPath
-                          type: object
-                        resourceFieldRef:
-                          description: 'Selects a resource of the container: only
-                            resources limits and requests (limits.cpu, limits.memory,
-                            limits.ephemeral-storage, requests.cpu, requests.memory
-                            and requests.ephemeral-storage) are currently supported.'
-                          properties:
-                            containerName:
-                              description: 'Container name: required for volumes,
-                                optional for env vars'
-                              type: string
-                            divisor:
-                              description: Specifies the output format of the exposed
-                                resources, defaults to "1"
-                              type: string
-                            resource:
-                              description: 'Required: resource to select'
-                              type: string
-                          required:
-                          - resource
-                          type: object
-                        secretKeyRef:
-                          description: Selects a key of a secret in the pod's namespace
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or it's key
-                                must be defined
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                      type: object
-                  required:
-                  - name
+    singular: wildflyserver
+  scope: Namespaced
+  subresources:
+    scale:
+      specReplicasPath: .spec.replicas
+      statusReplicasPath: .status.replicas
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            applicationImage:
+              description: ApplicationImage is the name of the application image to
+                be deployed
+              type: string
+            disableHTTPRoute:
+              description: DisableHTTPRoute disables the creation a route to the HTTP
+                port of the application service (false if omitted)
+              type: boolean
+            env:
+              description: Env contains environment variables for the containers running
+                the WildFlyServer application
+              items:
+                type: object
+              type: array
+            replicas:
+              description: Replicas is the desired number of replicas for the application
+              format: int32
+              type: integer
+            serviceAccountName:
+              type: string
+            sessionAffinity:
+              description: SessionAffinity defines if connections from the same client
+                ip are passed to the same WildFlyServer instance/pod each time (false
+                if omitted)
+              type: boolean
+            standaloneConfigMap:
+              properties:
+                key:
+                  description: Key of the config map whose value is the standalone
+                    XML configuration file ("standalone.xml" if omitted)
+                  type: string
+                name:
+                  type: string
+              required:
+              - name
+              type: object
+            storage:
+              description: StorageSpec defines specific storage required for the server
+                own data directory. If omitted, an EmptyDir is used (that will not
+                persist data across pod restart).
+              properties:
+                emptyDir:
                   type: object
-                type: array
-              envFrom:
-                items:
-                  description: EnvFromSource represents the source of a set of ConfigMaps
-                  properties:
-                    configMapRef:
-                      description: The ConfigMap to select from
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                        optional:
-                          description: Specify whether the ConfigMap must be defined
-                          type: boolean
-                      type: object
-                    prefix:
-                      description: An optional identifier to prepend to each key in
-                        the ConfigMap. Must be a C_IDENTIFIER.
-                      type: string
-                    secretRef:
-                      description: The Secret to select from
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                        optional:
-                          description: Specify whether the Secret must be defined
-                          type: boolean
-                      type: object
+                volumeClaimTemplate:
                   type: object
-                type: array
-              serviceAccountName:
+              type: object
+          required:
+          - applicationImage
+          - replicas
+          type: object
+        status:
+          properties:
+            hosts:
+              items:
                 type: string
-              sessionAffinity:
-                description: SessionAffinity defines if connections from the same
-                  client ip are passed to the same WildFlyServer instance/pod each
-                  time (false if omitted)
-                type: boolean
-              size:
-                format: int32
-                type: integer
-              standaloneConfigMap:
-                description: StandaloneConfigMapSpec defines the desired configMap
-                  configuration to obtain the standalone configuration for WildFlyServer
+              type: array
+            pods:
+              items:
                 properties:
-                  key:
-                    description: Key of the config map whose value is the standalone
-                      XML configuration file ("standalone.xml" if omitted)
-                    type: string
                   name:
+                    type: string
+                  podIP:
+                    type: string
+                  state:
+                    description: Represent the state of the Pod, it's used especially
+                      during scale down the expected values are represented by the
+                      PodState* constants  Read-only.
                     type: string
                 required:
                 - name
+                - podIP
+                - state
                 type: object
-              storage:
-                description: StorageSpec defines specific storage required for the
-                  server own data directory. If omitted, an EmptyDir is used (that
-                  will not persist data across pod restart).
-                properties:
-                  emptyDir:
-                    description: Represents an empty directory for a pod. Empty directory
-                      volumes support ownership management and SELinux relabeling.
-                    properties:
-                      medium:
-                        description: 'What type of storage medium should back this
-                          directory. The default is "" which means to use the node''s
-                          default medium. Must be an empty string (default) or Memory.
-                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                        type: string
-                      sizeLimit:
-                        description: 'Total amount of local storage required for this
-                          EmptyDir volume. The size limit is also applicable for memory
-                          medium. The maximum usage on memory medium EmptyDir would
-                          be the minimum value between the SizeLimit specified here
-                          and the sum of memory limits of all containers in a pod.
-                          The default is nil which means that the limit is undefined.
-                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                        type: string
-                    type: object
-                  volumeClaimTemplate:
-                    description: PersistentVolumeClaim is a user's request for and
-                      claim to a persistent volume
-                    properties:
-                      apiVersion:
-                        description: 'APIVersion defines the versioned schema of this
-                          representation of an object. Servers should convert recognized
-                          schemas to the latest internal value, and may reject unrecognized
-                          values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-                        type: string
-                      kind:
-                        description: 'Kind is a string value representing the REST
-                          resource this object represents. Servers may infer this
-                          from the endpoint the client submits requests to. Cannot
-                          be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-                        type: string
-                      metadata:
-                        description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-                        type: object
-                      spec:
-                        description: 'Spec defines the desired characteristics of
-                          a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                        properties:
-                          accessModes:
-                            description: 'AccessModes contains the desired access
-                              modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                            items:
-                              type: string
-                            type: array
-                          dataSource:
-                            description: This field requires the VolumeSnapshotDataSource
-                              alpha feature gate to be enabled and currently VolumeSnapshot
-                              is the only supported data source. If the provisioner
-                              can support VolumeSnapshot data source, it will create
-                              a new volume and data will be restored to the volume
-                              at the same time. If the provisioner does not support
-                              VolumeSnapshot data source, volume will not be created
-                              and the failure will be reported as an event. In the
-                              future, we plan to support more data source types and
-                              the behavior of the provisioner may change.
-                            properties:
-                              apiGroup:
-                                description: APIGroup is the group for the resource
-                                  being referenced. If APIGroup is not specified,
-                                  the specified Kind must be in the core API group.
-                                  For any other third-party types, APIGroup is required.
-                                type: string
-                              kind:
-                                description: Kind is the type of resource being referenced
-                                type: string
-                              name:
-                                description: Name is the name of resource being referenced
-                                type: string
-                            required:
-                            - kind
-                            - name
-                            type: object
-                          resources:
-                            description: 'Resources represents the minimum resources
-                              the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                            properties:
-                              limits:
-                                additionalProperties:
-                                  type: string
-                                description: 'Limits describes the maximum amount
-                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                type: object
-                              requests:
-                                additionalProperties:
-                                  type: string
-                                description: 'Requests describes the minimum amount
-                                  of compute resources required. If Requests is omitted
-                                  for a container, it defaults to Limits if that is
-                                  explicitly specified, otherwise to an implementation-defined
-                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                type: object
-                            type: object
-                          selector:
-                            description: A label query over volumes to consider for
-                              binding.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                          storageClassName:
-                            description: 'Name of the StorageClass required by the
-                              claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                            type: string
-                          volumeMode:
-                            description: volumeMode defines what type of volume is
-                              required by the claim. Value of Filesystem is implied
-                              when not included in claim spec. This is a beta feature.
-                            type: string
-                          volumeName:
-                            description: VolumeName is the binding reference to the
-                              PersistentVolume backing this claim.
-                            type: string
-                        type: object
-                      status:
-                        description: 'Status represents the current information/status
-                          of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                        properties:
-                          accessModes:
-                            description: 'AccessModes contains the actual access modes
-                              the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                            items:
-                              type: string
-                            type: array
-                          capacity:
-                            additionalProperties:
-                              type: string
-                            description: Represents the actual resources of the underlying
-                              volume.
-                            type: object
-                          conditions:
-                            description: Current Condition of persistent volume claim.
-                              If underlying persistent volume is being resized then
-                              the Condition will be set to 'ResizeStarted'.
-                            items:
-                              description: PersistentVolumeClaimCondition contails
-                                details about state of pvc
-                              properties:
-                                lastProbeTime:
-                                  description: Last time we probed the condition.
-                                  format: date-time
-                                  type: string
-                                lastTransitionTime:
-                                  description: Last time the condition transitioned
-                                    from one status to another.
-                                  format: date-time
-                                  type: string
-                                message:
-                                  description: Human-readable message indicating details
-                                    about last transition.
-                                  type: string
-                                reason:
-                                  description: Unique, this should be a short, machine
-                                    understandable string that gives the reason for
-                                    condition's last transition. If it reports "ResizeStarted"
-                                    that means the underlying persistent volume is
-                                    being resized.
-                                  type: string
-                                status:
-                                  type: string
-                                type:
-                                  description: PersistentVolumeClaimConditionType
-                                    is a valid value of PersistentVolumeClaimCondition.Type
-                                  type: string
-                              required:
-                              - status
-                              - type
-                              type: object
-                            type: array
-                          phase:
-                            description: Phase represents the current phase of PersistentVolumeClaim.
-                            type: string
-                        type: object
-                    type: object
-                type: object
-            required:
-            - applicationImage
-            - size
-            type: object
-          status:
-            description: WildFlyServerStatus defines the observed state of WildFlyServer
-            properties:
-              hosts:
-                items:
-                  type: string
-                type: array
-              pods:
-                items:
-                  description: PodStatus defines the observed state of pods running
-                    the WildFlyServer application
-                  properties:
-                    name:
-                      type: string
-                    podIP:
-                      type: string
-                    state:
-                      description: "Represent the state of the Pod, it's used especially
-                        during scale down the expected values are represented by the
-                        PodState* constants \n Read-only."
-                      type: string
-                  required:
-                  - name
-                  - podIP
-                  - state
-                  type: object
-                type: array
-              scalingdownPods:
-                description: "Represents the number of pods which are in scaledown
-                  process what particular pod is scaling down can be verified by PodStatus
-                  \n Read-only."
-                format: int32
-                type: integer
-            required:
-            - scalingdownPods
-            type: object
-        type: object
+              type: array
+            replicas:
+              description: Replicas is the actual number of replicas for the application
+              format: int32
+              type: integer
+            scalingdownPods:
+              description: Represents the number of pods which are in scaledown process
+                what particular pod is scaling down can be verified by PodStatus  Read-only.
+              format: int32
+              type: integer
+          required:
+          - replicas
+          - scalingdownPods
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
     served: true
     storage: true
-    subresources:
-      status: {}

--- a/doc/apis.adoc
+++ b/doc/apis.adoc
@@ -40,7 +40,7 @@ It uses a `StatefulSet` with a pod spec that mounts the volume specified by `sto
 |=======================
 | Field  | Description |Scheme| Required
 | `applicationImage` | Name of the application image to be deployed | string | true
-| `size` | Number of instances for a `WildFlyServer` resource | int32 | true
+| `replicas` | Replicas is the desired number of replicas for the application | int32 | true
 | `standaloneConfigMap` | spec to specify how standalone configuration can be read from a `ConfigMap` | *<<standaloneconfigmapspec>> |false
 | `storage` | Storage spec to specify how storage should be used. If omitted, an `EmptyDir` is used (that will not persist data across pod restart| *<<storagespec>> |false
 | `serviceAccountName` | Name of the ServiceAccount to use to run the WildFlyServer Pods | string | false
@@ -89,6 +89,7 @@ transaction, make sure to specify a `volumeClaimTemplate` that so that the same 
 [options="header,footer"]
 |=======================
 | Field  | Description |Scheme| Required
+| `replicas` | Replicas is the actual number of replicas for the application | int32 | true
 | `hosts` | Hosts that route to the application HTTP service | []string | true
 | `pods` | Status of the pods | []<<podstatus>> | true
 | `scalingdownPods` | Number of pods which are under scale down cleaning process | int32 | true

--- a/doc/user-guide.adoc
+++ b/doc/user-guide.adoc
@@ -32,13 +32,13 @@ The `applicationImage` accepts different references to Docker image:
 [[size]]
 ## Specify the Size of the Application
 
-The `size` specifies the size of the application, i.e. the number of pods that runs the application image.
+The `replicas` specifies the size of the application, i.e. the number of pods that runs the application image.
 
 [source,yaml]
 .Example of size configuration
 ----
 spec:
-  size:2
+  replicas:2
 ----
 
 [[storage]]

--- a/pkg/apis/wildfly/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/wildfly/v1alpha1/zz_generated.openapi.go
@@ -25,7 +25,6 @@ func schema_pkg_apis_wildfly_v1alpha1_PodStatus(ref common.ReferenceCallback) co
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "PodStatus defines the observed state of pods running the WildFlyServer application",
-				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
@@ -50,6 +49,7 @@ func schema_pkg_apis_wildfly_v1alpha1_PodStatus(ref common.ReferenceCallback) co
 				Required: []string{"name", "podIP", "state"},
 			},
 		},
+		Dependencies: []string{},
 	}
 }
 
@@ -58,7 +58,6 @@ func schema_pkg_apis_wildfly_v1alpha1_StandaloneConfigMapSpec(ref common.Referen
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "StandaloneConfigMapSpec defines the desired configMap configuration to obtain the standalone configuration for WildFlyServer",
-				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
@@ -77,6 +76,7 @@ func schema_pkg_apis_wildfly_v1alpha1_StandaloneConfigMapSpec(ref common.Referen
 				Required: []string{"name"},
 			},
 		},
+		Dependencies: []string{},
 	}
 }
 
@@ -85,7 +85,6 @@ func schema_pkg_apis_wildfly_v1alpha1_StorageSpec(ref common.ReferenceCallback) 
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "StorageSpec defines the desired storage for WildFlyServer",
-				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"emptyDir": {
 						SchemaProps: spec.SchemaProps{
@@ -110,7 +109,6 @@ func schema_pkg_apis_wildfly_v1alpha1_WildFlyServer(ref common.ReferenceCallback
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "WildFlyServer is the Schema for the wildflyservers API",
-				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
@@ -154,7 +152,6 @@ func schema_pkg_apis_wildfly_v1alpha1_WildFlyServerSpec(ref common.ReferenceCall
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "WildFlyServerSpec defines the desired state of WildFlyServer",
-				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"applicationImage": {
 						SchemaProps: spec.SchemaProps{
@@ -163,10 +160,11 @@ func schema_pkg_apis_wildfly_v1alpha1_WildFlyServerSpec(ref common.ReferenceCall
 							Format:      "",
 						},
 					},
-					"size": {
+					"replicas": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Description: "Replicas is the desired number of replicas for the application",
+							Type:        []string{"integer"},
+							Format:      "int32",
 						},
 					},
 					"sessionAffinity": {
@@ -202,7 +200,8 @@ func schema_pkg_apis_wildfly_v1alpha1_WildFlyServerSpec(ref common.ReferenceCall
 					},
 					"envFrom": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "EnvFrom contains environment variables from a source such as a ConfigMap or a Secret",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -226,7 +225,7 @@ func schema_pkg_apis_wildfly_v1alpha1_WildFlyServerSpec(ref common.ReferenceCall
 						},
 					},
 				},
-				Required: []string{"applicationImage", "size"},
+				Required: []string{"applicationImage", "replicas"},
 			},
 		},
 		Dependencies: []string{
@@ -239,8 +238,14 @@ func schema_pkg_apis_wildfly_v1alpha1_WildFlyServerStatus(ref common.ReferenceCa
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "WildFlyServerStatus defines the observed state of WildFlyServer",
-				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"replicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Replicas is the actual number of replicas for the application",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"pods": {
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
@@ -274,7 +279,7 @@ func schema_pkg_apis_wildfly_v1alpha1_WildFlyServerStatus(ref common.ReferenceCa
 						},
 					},
 				},
-				Required: []string{"scalingdownPods"},
+				Required: []string{"replicas", "scalingdownPods"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/controller/wildflyserver/wildflyserver_controller_test.go
+++ b/pkg/controller/wildflyserver/wildflyserver_controller_test.go
@@ -44,7 +44,7 @@ func TestWildFlyServerControllerCreatesStatefulSet(t *testing.T) {
 		},
 		Spec: wildflyv1alpha1.WildFlyServerSpec{
 			ApplicationImage: applicationImage,
-			Size:             replicas,
+			Replicas:             replicas,
 			SessionAffinity:  sessionAffinity,
 		},
 	}
@@ -117,7 +117,7 @@ func TestEnvUpdate(t *testing.T) {
 		},
 		Spec: wildflyv1alpha1.WildFlyServerSpec{
 			ApplicationImage: applicationImage,
-			Size:             0,
+			Replicas:             0,
 			SessionAffinity:  sessionAffinity,
 			Env: []corev1.EnvVar{
 				*initialEnv,
@@ -249,7 +249,7 @@ func TestWildFlyServerControllerScaleDown(t *testing.T) {
 		},
 		Spec: wildflyv1alpha1.WildFlyServerSpec{
 			ApplicationImage: applicationImage,
-			Size:             expectedReplicaSize,
+			Replicas:             expectedReplicaSize,
 			SessionAffinity:  sessionAffinity,
 		},
 	}
@@ -310,7 +310,7 @@ func TestWildFlyServerControllerScaleDown(t *testing.T) {
 		"WildflyServer", wildflyServer)
 	assert.Equal(int(expectedReplicaSize), len(wildflyServer.Status.Pods))
 	assert.Equal(wildflyv1alpha1.PodStateActive, wildflyServer.Status.Pods[0].State)
-	wildflyServer.Spec.Size = 0
+	wildflyServer.Spec.Replicas = 0
 	err = cl.Update(context.TODO(), wildflyServer)
 
 	// Reconcile for the scale down - updating the pod labels

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -41,7 +41,7 @@ func GetOrCreateNewStatefulSet(w *wildflyv1alpha1.WildFlyServer, client client.C
 
 // NewStatefulSet retunrs a new statefulset
 func NewStatefulSet(w *wildflyv1alpha1.WildFlyServer, labels map[string]string) *appsv1.StatefulSet {
-	replicas := w.Spec.Size
+	replicas := w.Spec.Replicas
 	applicationImage := w.Spec.ApplicationImage
 	volumeName := w.Name + "-volume"
 	labesForActiveWildflyPod := labels

--- a/test/framework/common.go
+++ b/test/framework/common.go
@@ -73,12 +73,12 @@ func wildflyBasicServerScaleTest(t *testing.T, f *framework.Framework, ctx *fram
 	if err != nil {
 		return err
 	}
-	wildflyServer.Spec.Size = 2
+	wildflyServer.Spec.Replicas = 2
 	err = f.Client.Update(context, wildflyServer)
 	if err != nil {
 		return err
 	}
-	t.Logf("Updated application %s size to %d\n", name, wildflyServer.Spec.Size)
+	t.Logf("Updated application %s size to %d\n", name, wildflyServer.Spec.Replicas)
 
 	// check that the resource have been updated
 	return WaitUntilReady(f, t, wildflyServer)
@@ -173,26 +173,26 @@ func WildflyScaleDownTest(t *testing.T, applicationTag string) {
 	if err != nil {
 		t.Fatalf("Failed to obtain the WildflyServer resource: %v", err)
 	}
-	if wildflyServer.Spec.Size != 2 {
-		t.Fatalf("The created %s customer resource should be defined with 2 instances but it's %v: %v", name, wildflyServer.Spec.Size, err)
+	if wildflyServer.Spec.Replicas != 2 {
+		t.Fatalf("The created %s customer resource should be defined with 2 instances but it's %v: %v", name, wildflyServer.Spec.Replicas, err)
 	}
 	// waiting for statefulset to scale to two instances
 	if err = WaitUntilReady(f, t, wildflyServer); err != nil {
 		t.Fatalf("Failed during waiting till %s customer resource is updated and ready: %v", name, err)
 	}
-	t.Logf("Application %s is deployed with %d instances\n", name, wildflyServer.Spec.Size)
+	t.Logf("Application %s is deployed with %d instances\n", name, wildflyServer.Spec.Replicas)
 
 	// scaling down by one
 	err = f.Client.Get(context, types.NamespacedName{Name: name, Namespace: namespace}, wildflyServer)
 	if err != nil {
 		t.Fatalf("Failed to obtain the WildflyServer resource for scaling it down: %v", err)
 	}
-	wildflyServer.Spec.Size = 1
+	wildflyServer.Spec.Replicas = 1
 	err = f.Client.Update(context, wildflyServer)
 	if err != nil {
 		t.Fatalf("Failed to update size of %s resource by decreasing the spec size: %v", name, err)
 	}
-	t.Logf("Updated application customer resource %s size to %d\n", name, wildflyServer.Spec.Size)
+	t.Logf("Updated application customer resource %s size to %d\n", name, wildflyServer.Spec.Replicas)
 
 	// check that the resource has been updated
 	if err = WaitUntilReady(f, t, wildflyServer); err != nil {

--- a/test/framework/wildlfyserver.go
+++ b/test/framework/wildlfyserver.go
@@ -42,7 +42,7 @@ func MakeBasicWildFlyServer(ns, name, applicationImage string, size int32) *wild
 		},
 		Spec: wildflyv1alpha1.WildFlyServerSpec{
 			ApplicationImage: applicationImage,
-			Size:             size,
+			Replicas:             size,
 		},
 	}
 }
@@ -111,7 +111,7 @@ func CreateAndWaitUntilReady(f *framework.Framework, ctx *framework.TestCtx, t *
 func WaitUntilReady(f *framework.Framework, t *testing.T, server *wildflyv1alpha1.WildFlyServer) error {
 	name := server.ObjectMeta.Name
 	ns := server.ObjectMeta.Namespace
-	size := server.Spec.Size
+	size := server.Spec.Replicas
 
 	t.Logf("Waiting until statefulset %s is ready with size of %v", name, size)
 


### PR DESCRIPTION
* update codegen based on operator-sdk 0.10.0
* rename Size to Replicas in the Spec and add a Replicas in the status
  to support the scale subresource
* use kubebuilder to generate CRD (including shortnames, subresources,
  etc.)
* add Replicas and Age to the printer columns

This fixes #33