### PR TITLE
[#91] Support secrets

### DIFF
--- a/deploy/crds/wildfly_v1alpha1_wildflyserver_crd.yaml
+++ b/deploy/crds/wildfly_v1alpha1_wildflyserver_crd.yaml
@@ -59,6 +59,13 @@ spec:
               description: Replicas is the desired number of replicas for the application
               format: int32
               type: integer
+            secrets:
+              description: Secrets is a list of Secrets in the same namespace as the
+                WildFlyServer object, which shall be mounted into the WildFlyServer
+                Pods. The Secrets are mounted into /etc/secrets/<secret-name>.
+              items:
+                type: string
+              type: array
             serviceAccountName:
               type: string
             sessionAffinity:

--- a/doc/apis.adoc
+++ b/doc/apis.adoc
@@ -46,6 +46,7 @@ It uses a `StatefulSet` with a pod spec that mounts the volume specified by `sto
 | `serviceAccountName` | Name of the ServiceAccount to use to run the WildFlyServer Pods | string | false
 | `envFrom` | List of environment variable present in the containers from source (either `ConfigMap` or `Secret`) | []https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#envfromsource-v1-core[corev1.EnvFromSource] |false
 | `env` | List of environment variable present in the containers | []https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#envvar-v1-core[corev1.EnvVar] | false
+| `secrets` | List of secret names to mount as volumes in the containers. Each secret is mounted as a read-only volume under `/etc/secrets/<secret name>` | string[] | false 
 | `disableHTTPRoute`| Disable the creation a route to the HTTP port of the application service (false if omitted) | bool | false
 | `sessionAffinity`| If connections from the same client IP are passed to the same WildFlyServer instance/pod each time (false if omitted) | bool | false
 |=======================

--- a/doc/user-guide.adoc
+++ b/doc/user-guide.adoc
@@ -96,6 +96,41 @@ spec:
         name: postgresql
 ----
 
+[[secret]]
+## Configure Secrets
+
+Secrets can be mounted as volumes to be accessed from the application.
+
+The secrets must be created *before* the WildFly Operator deploys the application. For example we can create a secret named `my-secret` with a command such as:
+
+[source,shell]
+----
+$ kubectl create secret generic my-secret --from-literal=my-key=devuser --from-literal=my-password='my-very-secure-pasword'
+----
+
+Once the secret has been created, we can specify its name in the WildFlyServer Spec to have it mounted as a volume in the pods running the application:
+
+[source,yaml]
+.Example of mounting secrets
+----
+spec:
+  secrets:
+    - my-secret
+----
+
+The secrets will then be mounted under `/etc/secrets/<secret name>` and each key/value will be stored in a file (whose name is the key and the content is the value).
+
+[source,shell]
+.Secret is mounted as a volume inside the Pod
+----
+[jboss@quickstart-0 ~]$ ls /etc/secrets/my-secret/
+my-key  my-password
+[jboss@quickstart-0 ~]$ cat /etc/secrets/my-secret/my-key
+devuser
+[jboss@quickstart-0 ~]$ cat /etc/secrets/my-secret/my-password
+my-very-secure-pasword
+----
+
 [[standalone-config-map]]
 ## Bring Your Own Standalone XML Configuation
 

--- a/pkg/apis/wildfly/v1alpha1/wildflyserver_types.go
+++ b/pkg/apis/wildfly/v1alpha1/wildflyserver_types.go
@@ -28,6 +28,10 @@ type WildFlyServerSpec struct {
 	EnvFrom []corev1.EnvFromSource `json:"envFrom,omitempty,list_type=corev1.EnvFromSource"`
 	// Env contains environment variables for the containers running the WildFlyServer application
 	Env []corev1.EnvVar `json:"env,omitempty"`
+	// Secrets is a list of Secrets in the same namespace as the WildFlyServer
+	// object, which shall be mounted into the WildFlyServer Pods.
+	// The Secrets are mounted into /etc/secrets/<secret-name>.
+	Secrets []string `json:"secrets,omitempty"`
 }
 
 // StandaloneConfigMapSpec defines the desired configMap configuration to obtain the standalone configuration for WildFlyServer

--- a/pkg/apis/wildfly/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/wildfly/v1alpha1/zz_generated.deepcopy.go
@@ -151,6 +151,11 @@ func (in *WildFlyServerSpec) DeepCopyInto(out *WildFlyServerSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Secrets != nil {
+		in, out := &in.Secrets, &out.Secrets
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/wildfly/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/wildfly/v1alpha1/zz_generated.openapi.go
@@ -224,6 +224,20 @@ func schema_pkg_apis_wildfly_v1alpha1_WildFlyServerSpec(ref common.ReferenceCall
 							},
 						},
 					},
+					"secrets": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Secrets is a list of Secrets in the same namespace as the WildFlyServer object, which shall be mounted into the WildFlyServer Pods. The Secrets are mounted into /etc/secrets/<secret-name>.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"applicationImage", "replicas"},
 			},

--- a/pkg/controller/wildflyserver/wildflyserver_controller_test.go
+++ b/pkg/controller/wildflyserver/wildflyserver_controller_test.go
@@ -44,7 +44,7 @@ func TestWildFlyServerControllerCreatesStatefulSet(t *testing.T) {
 		},
 		Spec: wildflyv1alpha1.WildFlyServerSpec{
 			ApplicationImage: applicationImage,
-			Replicas:             replicas,
+			Replicas:         replicas,
 			SessionAffinity:  sessionAffinity,
 		},
 	}
@@ -117,7 +117,7 @@ func TestEnvUpdate(t *testing.T) {
 		},
 		Spec: wildflyv1alpha1.WildFlyServerSpec{
 			ApplicationImage: applicationImage,
-			Replicas:             0,
+			Replicas:         0,
 			SessionAffinity:  sessionAffinity,
 			Env: []corev1.EnvVar{
 				*initialEnv,
@@ -249,7 +249,7 @@ func TestWildFlyServerControllerScaleDown(t *testing.T) {
 		},
 		Spec: wildflyv1alpha1.WildFlyServerSpec{
 			ApplicationImage: applicationImage,
-			Replicas:             expectedReplicaSize,
+			Replicas:         expectedReplicaSize,
 			SessionAffinity:  sessionAffinity,
 		},
 	}
@@ -327,6 +327,93 @@ func TestWildFlyServerControllerScaleDown(t *testing.T) {
 	err = cl.Get(context.TODO(), req.NamespacedName, wildflyServer)
 	require.NoError(t, err)
 	assert.Equal(wildflyv1alpha1.PodStateScalingDownRecoveryInvestigation, wildflyServer.Status.Pods[0].State)
+}
+
+func TestWildFlyServerWithSecret(t *testing.T) {
+	// Set the logger to development mode for verbose logs.
+	logf.SetLogger(logf.ZapLogger(true))
+	assert := assert.New(t)
+
+	secretName := "mysecret"
+	secretKey := "my-key"
+	secretValue := "my-very-secure-value"
+
+	// A WildFlyServer resource with metadata and spec.
+	wildflyServer := &wildflyv1alpha1.WildFlyServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: wildflyv1alpha1.WildFlyServerSpec{
+			ApplicationImage: applicationImage,
+			Replicas:         replicas,
+			Secrets:          []string{secretName},
+		},
+	}
+	// Objects to track in the fake client.
+	objs := []runtime.Object{
+		wildflyServer,
+	}
+
+	// Register operator types with the runtime scheme.
+	s := scheme.Scheme
+	s.AddKnownTypes(wildflyv1alpha1.SchemeGroupVersion, wildflyServer)
+	// Create a fake client to mock API calls.
+	cl := fake.NewFakeClient(objs...)
+	// Create a ReconcileWildFlyServer object with the scheme and fake client.
+	r := &ReconcileWildFlyServer{client: cl, scheme: s}
+
+	err := cl.Create(context.TODO(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		StringData: map[string]string{
+			secretKey: secretValue,
+		},
+	})
+	require.NoError(t, err)
+
+	// Mock request to simulate Reconcile() being called on an event for a
+	// watched resource .
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	// statefulset will be created
+	_, err = r.Reconcile(req)
+	require.NoError(t, err)
+
+	// Check if stateful set has been created and has the correct size.
+	statefulSet := &appsv1.StatefulSet{}
+	err = cl.Get(context.TODO(), req.NamespacedName, statefulSet)
+	require.NoError(t, err)
+	assert.Equal(replicas, *statefulSet.Spec.Replicas)
+	assert.Equal(applicationImage, statefulSet.Spec.Template.Spec.Containers[0].Image)
+
+	foundVolume := false
+	for _, v := range statefulSet.Spec.Template.Spec.Volumes {
+		if v.Name == "secret-"+secretName {
+			source := v.VolumeSource
+			if source.Secret.SecretName == secretName {
+				foundVolume = true
+				break
+			}
+		}
+	}
+	assert.True(foundVolume)
+
+	foundVolumeMount := false
+	for _, vm := range statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts {
+		if vm.Name == "secret-"+secretName {
+			assert.Equal("/etc/secrets/"+secretName, vm.MountPath)
+			assert.True(vm.ReadOnly)
+			foundVolumeMount = true
+		}
+	}
+	assert.True(foundVolumeMount)
 }
 
 type eventRecorderMock struct {

--- a/pkg/resources/constants.go
+++ b/pkg/resources/constants.go
@@ -15,6 +15,8 @@ const (
 	MarkerOperatedByLoadbalancer = "wildfly.org/operated-by-loadbalancer"
 	// MarkerOperatedByHeadless is a label used to remove a pod from receiving load from headless service when it's cleaned to shutdown
 	MarkerOperatedByHeadless = "wildfly.org/operated-by-headless"
+	// SecretsDir is the the directory to mount volumes from Secrets
+	SecretsDir = "/etc/secrets/"
 )
 
 var (


### PR DESCRIPTION
Secrets can be mounted as volumes inside the Pods running the
applications by adding their names to the WildFlyServerSpec.Secrets
field.

Secrets will be mounted under `/etc/secrets/<secret name>`.

This fixes #91.