### PR TITLE
[#92] Support Config Maps

### DIFF
--- a/deploy/crds/wildfly_v1alpha1_wildflyserver_crd.yaml
+++ b/deploy/crds/wildfly_v1alpha1_wildflyserver_crd.yaml
@@ -45,6 +45,13 @@ spec:
               description: ApplicationImage is the name of the application image to
                 be deployed
               type: string
+            configMaps:
+              description: ConfigMaps is a list of ConfigMaps in the same namespace
+                as the WildFlyServer object, which shall be mounted into the WildFlyServer
+                Pods. The ConfigMaps are mounted into /etc/configmaps/<configmap-name>.
+              items:
+                type: string
+              type: array
             disableHTTPRoute:
               description: DisableHTTPRoute disables the creation a route to the HTTP
                 port of the application service (false if omitted)

--- a/doc/apis.adoc
+++ b/doc/apis.adoc
@@ -47,6 +47,7 @@ It uses a `StatefulSet` with a pod spec that mounts the volume specified by `sto
 | `envFrom` | List of environment variable present in the containers from source (either `ConfigMap` or `Secret`) | []https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#envfromsource-v1-core[corev1.EnvFromSource] |false
 | `env` | List of environment variable present in the containers | []https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#envvar-v1-core[corev1.EnvVar] | false
 | `secrets` | List of secret names to mount as volumes in the containers. Each secret is mounted as a read-only volume under `/etc/secrets/<secret name>` | string[] | false 
+| `configMaps` | List of ConfigMap names to mount as volumes in the containers. Each config map is mounted as a read-only volume under `/etc/configmaps/<config map name>` | string[] | false
 | `disableHTTPRoute`| Disable the creation a route to the HTTP port of the application service (false if omitted) | bool | false
 | `sessionAffinity`| If connections from the same client IP are passed to the same WildFlyServer instance/pod each time (false if omitted) | bool | false
 |=======================

--- a/doc/user-guide.adoc
+++ b/doc/user-guide.adoc
@@ -131,6 +131,42 @@ devuser
 my-very-secure-pasword
 ----
 
+[[configmaps]]
+## Configure ConfigMaps
+
+ConfigMaps can be mounted as volumes to be accessed from the application.
+
+The config maps must be created *before* the WildFly Operator deploys the application. For example we can create a config map named `my-config` with a command such as:
+
+[source,shell]
+----
+$ kubectl create configmap my-config --from-literal=key1=value1 --from-literal=key2=value2
+configmap/my-config created
+----
+
+Once the secret has been created, we can specify its name in the WildFlyServer Spec to have it mounted as a volume in the pods running the application:
+
+[source,yaml]
+.Example of mounting config maps
+----
+spec:
+  configMaps:
+  - my-config
+----
+
+The config maps will then be mounted under `/etc/configmaps/<config map name>` and each key/value will be stored in a file (whose name is the key and the content is the value).
+
+[source,shell]
+.Config Map is mounted as a volume inside the Pod
+----
+[jboss@quickstart-0 ~]$ ls /etc/configmaps/my-config/
+key1 key2
+[jboss@quickstart-0 ~]$ cat /etc/configmaps/my-config/key1
+value1
+[jboss@quickstart-0 ~]$ cat /etc/configmaps/my-config/key2
+value2
+----
+
 [[standalone-config-map]]
 ## Bring Your Own Standalone XML Configuation
 

--- a/pkg/apis/wildfly/v1alpha1/wildflyserver_types.go
+++ b/pkg/apis/wildfly/v1alpha1/wildflyserver_types.go
@@ -32,6 +32,10 @@ type WildFlyServerSpec struct {
 	// object, which shall be mounted into the WildFlyServer Pods.
 	// The Secrets are mounted into /etc/secrets/<secret-name>.
 	Secrets []string `json:"secrets,omitempty"`
+	// ConfigMaps is a list of ConfigMaps in the same namespace as the WildFlyServer
+	// object, which shall be mounted into the WildFlyServer Pods.
+	// The ConfigMaps are mounted into /etc/configmaps/<configmap-name>.
+	ConfigMaps []string `json:"configMaps,omitempty"`
 }
 
 // StandaloneConfigMapSpec defines the desired configMap configuration to obtain the standalone configuration for WildFlyServer

--- a/pkg/apis/wildfly/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/wildfly/v1alpha1/zz_generated.deepcopy.go
@@ -156,6 +156,11 @@ func (in *WildFlyServerSpec) DeepCopyInto(out *WildFlyServerSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ConfigMaps != nil {
+		in, out := &in.ConfigMaps, &out.ConfigMaps
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/wildfly/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/wildfly/v1alpha1/zz_generated.openapi.go
@@ -238,6 +238,20 @@ func schema_pkg_apis_wildfly_v1alpha1_WildFlyServerSpec(ref common.ReferenceCall
 							},
 						},
 					},
+					"configMaps": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ConfigMaps is a list of ConfigMaps in the same namespace as the WildFlyServer object, which shall be mounted into the WildFlyServer Pods. The ConfigMaps are mounted into /etc/configmaps/<configmap-name>.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"applicationImage", "replicas"},
 			},

--- a/pkg/controller/wildflyserver/wildflyserver_controller_test.go
+++ b/pkg/controller/wildflyserver/wildflyserver_controller_test.go
@@ -416,6 +416,91 @@ func TestWildFlyServerWithSecret(t *testing.T) {
 	assert.True(foundVolumeMount)
 }
 
+func TestWildFlyServerWithConfigMap(t *testing.T) {
+	// Set the logger to development mode for verbose logs.
+	logf.SetLogger(logf.ZapLogger(true))
+	assert := assert.New(t)
+
+	configMapName := "my-config"
+
+	// A WildFlyServer resource with metadata and spec.
+	wildflyServer := &wildflyv1alpha1.WildFlyServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: wildflyv1alpha1.WildFlyServerSpec{
+			ApplicationImage: applicationImage,
+			Replicas:         replicas,
+			ConfigMaps:       []string{configMapName},
+		},
+	}
+	// Objects to track in the fake client.
+	objs := []runtime.Object{
+		wildflyServer,
+	}
+
+	// Register operator types with the runtime scheme.
+	s := scheme.Scheme
+	s.AddKnownTypes(wildflyv1alpha1.SchemeGroupVersion, wildflyServer)
+	// Create a fake client to mock API calls.
+	cl := fake.NewFakeClient(objs...)
+	// Create a ReconcileWildFlyServer object with the scheme and fake client.
+	r := &ReconcileWildFlyServer{client: cl, scheme: s}
+
+	err := cl.Create(context.TODO(), &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Data: map[string]string{
+			"key1": "value1",
+		},
+	})
+	require.NoError(t, err)
+
+	// Mock request to simulate Reconcile() being called on an event for a
+	// watched resource .
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	// statefulset will be created
+	_, err = r.Reconcile(req)
+	require.NoError(t, err)
+
+	// Check if stateful set has been created and has the correct size.
+	statefulSet := &appsv1.StatefulSet{}
+	err = cl.Get(context.TODO(), req.NamespacedName, statefulSet)
+	require.NoError(t, err)
+	assert.Equal(replicas, *statefulSet.Spec.Replicas)
+	assert.Equal(applicationImage, statefulSet.Spec.Template.Spec.Containers[0].Image)
+
+	foundVolume := false
+	for _, v := range statefulSet.Spec.Template.Spec.Volumes {
+		if v.Name == "configmap-"+configMapName {
+			source := v.VolumeSource
+			if source.ConfigMap.LocalObjectReference.Name == configMapName {
+				foundVolume = true
+				break
+			}
+		}
+	}
+	assert.True(foundVolume)
+
+	foundVolumeMount := false
+	for _, vm := range statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts {
+		if vm.Name == "configmap-"+configMapName {
+			assert.Equal("/etc/configmaps/"+configMapName, vm.MountPath)
+			assert.True(vm.ReadOnly)
+			foundVolumeMount = true
+		}
+	}
+	assert.True(foundVolumeMount)
+}
+
 type eventRecorderMock struct {
 }
 

--- a/pkg/resources/constants.go
+++ b/pkg/resources/constants.go
@@ -17,6 +17,8 @@ const (
 	MarkerOperatedByHeadless = "wildfly.org/operated-by-headless"
 	// SecretsDir is the the directory to mount volumes from Secrets
 	SecretsDir = "/etc/secrets/"
+	// ConfigMapsDir is the the directory to mount volumes from ConfigMaps
+	ConfigMapsDir = "/etc/configmaps/"
 )
 
 var (

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -17,7 +17,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -122,7 +121,7 @@ func NewStatefulSet(w *wildflyv1alpha1.WildFlyServer, labels map[string]string, 
 		emptyDir := storageSpec.EmptyDir
 		volumes = append(volumes, corev1.Volume{
 			Name: standaloneDataVolumeName,
-			VolumeSource: v1.VolumeSource{
+			VolumeSource: corev1.VolumeSource{
 				EmptyDir: emptyDir,
 			},
 		})
@@ -162,12 +161,12 @@ func NewStatefulSet(w *wildflyv1alpha1.WildFlyServer, labels map[string]string, 
 
 		volumes = append(volumes, corev1.Volume{
 			Name: "standalone-config-volume",
-			VolumeSource: v1.VolumeSource{
-				ConfigMap: &v1.ConfigMapVolumeSource{
-					LocalObjectReference: v1.LocalObjectReference{
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
 						Name: configMapName,
 					},
-					Items: []v1.KeyToPath{
+					Items: []corev1.KeyToPath{
 						{
 							Key:  configMapKey,
 							Path: "standalone.xml",
@@ -186,15 +185,15 @@ func NewStatefulSet(w *wildflyv1alpha1.WildFlyServer, labels map[string]string, 
 	// mount volumes from secrets
 	for _, s := range w.Spec.Secrets {
 		volumeName := wildflyutil.SanitizeVolumeName("secret-" + s)
-		volumes = append(volumes, v1.Volume{
+		volumes = append(volumes, corev1.Volume{
 			Name: volumeName,
-			VolumeSource: v1.VolumeSource{
-				Secret: &v1.SecretVolumeSource{
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					SecretName: s,
 				},
 			},
 		})
-		volumeMounts = append(volumeMounts, v1.VolumeMount{
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      volumeName,
 			ReadOnly:  true,
 			MountPath: resources.SecretsDir + s,
@@ -204,17 +203,17 @@ func NewStatefulSet(w *wildflyv1alpha1.WildFlyServer, labels map[string]string, 
 	// mount volumes from config maps
 	for _, cm := range w.Spec.ConfigMaps {
 		volumeName := wildflyutil.SanitizeVolumeName("configmap-" + cm)
-		volumes = append(volumes, v1.Volume{
+		volumes = append(volumes, corev1.Volume{
 			Name: volumeName,
-			VolumeSource: v1.VolumeSource{
-				ConfigMap: &v1.ConfigMapVolumeSource{
-					LocalObjectReference: v1.LocalObjectReference{
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
 						Name: cm,
 					},
 				},
 			},
 		})
-		volumeMounts = append(volumeMounts, v1.VolumeMount{
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      volumeName,
 			ReadOnly:  true,
 			MountPath: resources.ConfigMapsDir + cm,
@@ -237,7 +236,7 @@ func createLivenessProbe() *corev1.Probe {
 	if defined {
 		return &corev1.Probe{
 			Handler: corev1.Handler{
-				Exec: &v1.ExecAction{
+				Exec: &corev1.ExecAction{
 					Command: []string{"/bin/bash", "-c", livenessProbeScript},
 				},
 			},
@@ -246,7 +245,7 @@ func createLivenessProbe() *corev1.Probe {
 	}
 	return &corev1.Probe{
 		Handler: corev1.Handler{
-			HTTPGet: &v1.HTTPGetAction{
+			HTTPGet: &corev1.HTTPGetAction{
 				Path: "/health",
 				Port: intstr.FromString("admin"),
 			},
@@ -265,7 +264,7 @@ func createReadinessProbe() *corev1.Probe {
 	if defined {
 		return &corev1.Probe{
 			Handler: corev1.Handler{
-				Exec: &v1.ExecAction{
+				Exec: &corev1.ExecAction{
 					Command: []string{"/bin/bash", "-c", readinessProbeScript},
 				},
 			},

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -185,8 +185,9 @@ func NewStatefulSet(w *wildflyv1alpha1.WildFlyServer, labels map[string]string, 
 
 	// mount volumes from secrets
 	for _, s := range w.Spec.Secrets {
+		volumeName := wildflyutil.SanitizeVolumeName("secret-" + s)
 		volumes = append(volumes, v1.Volume{
-			Name: wildflyutil.SanitizeVolumeName("secret-" + s),
+			Name: volumeName,
 			VolumeSource: v1.VolumeSource{
 				Secret: &v1.SecretVolumeSource{
 					SecretName: s,
@@ -194,9 +195,29 @@ func NewStatefulSet(w *wildflyv1alpha1.WildFlyServer, labels map[string]string, 
 			},
 		})
 		volumeMounts = append(volumeMounts, v1.VolumeMount{
-			Name:      wildflyutil.SanitizeVolumeName("secret-" + s),
+			Name:      volumeName,
 			ReadOnly:  true,
 			MountPath: resources.SecretsDir + s,
+		})
+	}
+
+	// mount volumes from config maps
+	for _, cm := range w.Spec.ConfigMaps {
+		volumeName := wildflyutil.SanitizeVolumeName("configmap-" + cm)
+		volumes = append(volumes, v1.Volume{
+			Name: volumeName,
+			VolumeSource: v1.VolumeSource{
+				ConfigMap: &v1.ConfigMapVolumeSource{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: cm,
+					},
+				},
+			},
+		})
+		volumeMounts = append(volumeMounts, v1.VolumeMount{
+			Name:      volumeName,
+			ReadOnly:  true,
+			MountPath: resources.ConfigMapsDir + cm,
 		})
 	}
 


### PR DESCRIPTION
ConfigMaps can be mounted as volumes inside the Pods running the
applications by adding their names to the WildFlyServerSpec.ConfigMaps
field.

ConfigMaps will be mounted under `/etc/configmaps/<config map name>`.

This fixes #92.