### PR TITLE
Adding socket dial dead timeout when recovery would be stuck

### DIFF
--- a/pkg/controller/util/remote_ops.go
+++ b/pkg/controller/util/remote_ops.go
@@ -28,7 +28,8 @@ var (
 	// start of the time timestamp
 	startOfTheTimeTimestamp = time.Unix(0, 0)
 	// socket dial timeout
-	socketDialTimeout = GetEnvAsDuration("SOCKET_DIAL_TIMEOUT", 10, time.Second)
+	socketDialTimeout = GetEnvAsDuration("SOCKET_DIAL_TIMEOUT", 30, time.Second)
+	socketDeadTimeout = GetEnvAsDuration("SOCKET_DEAD_TIMEOUT", 10*60, time.Second)
 )
 
 //ExecRemote executes a command inside the remote pod
@@ -94,6 +95,7 @@ func SocketConnect(hostname string, port int32, command string) (string, error) 
 		return "", fmt.Errorf("Cannot process TCP connection to %v, error: %v",
 			toConnectTo, err)
 	}
+	conn.SetDeadline(time.Now().Add(socketDeadTimeout))
 	// send to socket
 	fmt.Fprintf(conn, command+"\n")
 	// blocking operation, listen for reply


### PR DESCRIPTION
Just a small fix on adding a timeout for a dead connection during recovery processing.

If the application server would be stuck for some reason it could let handing the connection. The dead timeout defines the time when recovery scan is considered as errorneous and the waiting will be released.