### PR TITLE
[#120] Error when resource already exists

### DIFF
--- a/pkg/controller/wildflyserver/wildflyserver_controller.go
+++ b/pkg/controller/wildflyserver/wildflyserver_controller.go
@@ -196,13 +196,13 @@ func (r *ReconcileWildFlyServer) Reconcile(request reconcile.Request) (reconcile
 	if err != nil {
 		return reconcile.Result{}, err
 	} else if loadBalancer == nil {
-		return reconcile.Result{}, nil
+		return reconcile.Result{Requeue: true}, nil
 	}
 	// Check if the headless service already exists, if not create a new one
 	if headlessService, err := services.CreateOrUpdateHeadlessService(wildflyServer, r.client, r.scheme, LabelsForWildFly(wildflyServer)); err != nil {
 		return reconcile.Result{}, err
 	} else if headlessService == nil {
-		return reconcile.Result{}, nil
+		return reconcile.Result{Requeue: true}, nil
 	}
 
 	// Check if the HTTP route must be created
@@ -212,7 +212,7 @@ func (r *ReconcileWildFlyServer) Reconcile(request reconcile.Request) (reconcile
 			if route, err = routes.GetOrCreateNewRoute(wildflyServer, r.client, r.scheme, LabelsForWildFly(wildflyServer)); err != nil {
 				return reconcile.Result{}, err
 			} else if route == nil {
-				return reconcile.Result{}, nil
+				return reconcile.Result{Requeue: true}, nil
 			}
 		} else {
 			// delete the route that may have been created by a previous generation of the WildFlyServer

--- a/pkg/resources/actions.go
+++ b/pkg/resources/actions.go
@@ -34,7 +34,6 @@ func Create(w *wildflyv1alpha1.WildFlyServer, client client.Client, scheme *runt
 	logger.Info("Set controller reference for new resource")
 
 	if err := client.Create(context.TODO(), objectDefinition); err != nil {
-		logger.Error(err, "Failed to create new resource")
 		return err
 	}
 

--- a/pkg/resources/routes/route.go
+++ b/pkg/resources/routes/route.go
@@ -19,6 +19,9 @@ func GetOrCreateNewRoute(w *wildflyv1alpha1.WildFlyServer, client client.Client,
 	if err := resources.Get(w, types.NamespacedName{Name: routeServiceName(w), Namespace: w.Namespace}, client, route); err != nil {
 		if errors.IsNotFound(err) {
 			if err := resources.Create(w, client, scheme, newRoute(w, labels)); err != nil {
+				if errors.IsAlreadyExists(err) {
+					return nil, nil
+				}
 				return nil, err
 			}
 			return nil, nil

--- a/pkg/resources/services/service.go
+++ b/pkg/resources/services/service.go
@@ -25,6 +25,9 @@ func CreateOrUpdateHeadlessService(w *wildflyv1alpha1.WildFlyServer, client clie
 	// create the service if it is not found
 	if errors.IsNotFound(err) {
 		if err := resources.Create(w, client, scheme, newHeadlessService(w, labels)); err != nil {
+			if errors.IsAlreadyExists(err) {
+				return nil, nil
+			}
 			return nil, err
 		}
 		return nil, nil
@@ -61,6 +64,12 @@ func CreateOrUpdateLoadBalancerService(w *wildflyv1alpha1.WildFlyServer, client 
 	// create the service if it is not found
 	if errors.IsNotFound(err) {
 		if err := resources.Create(w, client, scheme, newLoadBalancerService(w, labels)); err != nil {
+			// the resource may already exist if it was just created before and the reconcile loop is requesting
+			// the resource right after. In that case, we return nil, so the reconcile loop will run again
+			// and get the existing resource?
+			if errors.IsAlreadyExists(err) {
+				return nil, nil
+			}
 			return nil, err
 		}
 		return nil, nil


### PR DESCRIPTION
It seems there is a time window when a resource is created and when it
is fetched that results in an error.
When creating a resource, catch the AlreadyExists error and requeue the
key so that the reconcile loop will find the existing resource as
expected.

This fixes #120.