### PR TITLE
[#126] disable transaction manager on scale down pod

### DIFF
--- a/pkg/controller/util/wildfly_mgmt.go
+++ b/pkg/controller/util/wildfly_mgmt.go
@@ -37,6 +37,8 @@ var (
 	MgmtOpSystemPropertyPeriodicRecoveryPeriod = "/system-property=com.arjuna.ats.arjuna.common.RecoveryEnvironmentBean.periodicRecoveryPeriod:add(value=%s)"
 	// MgmtOpSystemPropertyOrphanSafetyInterval is a JBoss CLI command to set system property of orphan safety interval
 	MgmtOpSystemPropertyOrphanSafetyInterval = "/system-property=com.arjuna.ats.jta.common.JTAEnvironmentBean.orphanSafetyInterval:add(value=%s)"
+	// MgmtOpSystemPropertyTransactionManagerEnabled is a JBoss CLI command to set system property to enable/disable transaction manager
+	MgmtOpSystemPropertyTransactionManagerEnabled = "/system-property=com.arjuna.ats.arjuna.common.CoordinatorEnvironmentBean.startDisabled:add(value=%s)"
 )
 
 // IsMgmtOutcomeSuccesful verifies if the management operation was succcesfull

--- a/pkg/controller/wildflyserver/transaction_recovery.go
+++ b/pkg/controller/wildflyserver/transaction_recovery.go
@@ -170,9 +170,10 @@ func (r *ReconcileWildFlyServer) setupRecoveryPropertiesAndRestart(reqLogger log
 	scaleDownPodName := scaleDownPod.ObjectMeta.Name
 	// Setup and restart only if it was not done in the prior reconcile cycle
 	if scaleDownPod.Annotations[markerRecoveryPropertiesSetup] == "" {
-		reqLogger.Info("Setting up back-off period and orphan detection properties for scaledown transaction reocovery", "Pod Name", scaleDownPodName)
+		reqLogger.Info("Setting up back-off period and orphan detection properties for scaledown transaction recovery", "Pod Name", scaleDownPodName)
 		setPeriodOps := fmt.Sprintf(wildflyutil.MgmtOpSystemPropertyRecoveryBackoffPeriod, "1") + "," + fmt.Sprintf(wildflyutil.MgmtOpSystemPropertyOrphanSafetyInterval, "1")
-		jsonResult, errExecution := wildflyutil.ExecuteMgmtOp(scaleDownPod, setPeriodOps)
+		disableTMOp := fmt.Sprintf(wildflyutil.MgmtOpSystemPropertyTransactionManagerEnabled, "false")
+		jsonResult, errExecution := wildflyutil.ExecuteMgmtOp(scaleDownPod, setPeriodOps+","+disableTMOp)
 
 		// command may end-up with error with status 'rolled-back' which means duplication, thus do not check for error as error could be possitive outcome
 		isOperationRolledBack := wildflyutil.ReadJSONDataByIndex(jsonResult, "rolled-back")

--- a/pkg/controller/wildflyserver/transaction_recovery.go
+++ b/pkg/controller/wildflyserver/transaction_recovery.go
@@ -151,7 +151,7 @@ func (r *ReconcileWildFlyServer) checkRecovery(reqLogger logr.Logger, scaleDownP
 		return false, retString, nil
 	}
 	// Verification of the unfinished data of the WildFly transaction client (verification of the directory content)
-	lsCommand := fmt.Sprintf(`ls %s/%s/ 2> /dev/null || true`, resources.StandaloneServerDataDirPath, wftcDataDirName)
+	lsCommand := fmt.Sprintf(`ls ${JBOSS_HOME}/%s/%s/ 2> /dev/null || true`, resources.StandaloneServerDataDirRelativePath, wftcDataDirName)
 	commandResult, err := wildflyutil.ExecRemote(scaleDownPod, lsCommand)
 	if err != nil {
 		return false, "", fmt.Errorf("Cannot query filesystem at scaling down pod %v to check existing remote transactions. "+
@@ -159,8 +159,8 @@ func (r *ReconcileWildFlyServer) checkRecovery(reqLogger logr.Logger, scaleDownP
 	}
 	if commandResult != "" {
 		retString := fmt.Sprintf("WildFly Transaction Client data dir is not empty and scaling down of the pod '%v' will be retried."+
-			"Wildfly Transacton Client data dir path '%v', output listing: %v",
-			scaleDownPodName, resources.StandaloneServerDataDirPath+"/"+wftcDataDirName, commandResult)
+			"Wildfly Transacton Client data dir path '${JBOSS_HOME}/%v/%v', output listing: %v",
+			scaleDownPodName, resources.StandaloneServerDataDirRelativePath, wftcDataDirName, commandResult)
 		return false, retString, nil
 	}
 	return true, "", nil

--- a/pkg/resources/constants.go
+++ b/pkg/resources/constants.go
@@ -24,6 +24,6 @@ const (
 var (
 	// JBossHome is read from the env var JBOSS_HOME
 	JBossHome = os.Getenv("JBOSS_HOME")
-	// StandaloneServerDataDirPath is the path to the server standalone data directory
-	StandaloneServerDataDirPath = JBossHome + "/standalone/data"
+	// StandaloneServerDataDirRelativePath is the path to the server standalone data directory
+	StandaloneServerDataDirRelativePath = "standalone/data"
 )

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -149,7 +149,7 @@ func NewStatefulSet(w *wildflyv1alpha1.WildFlyServer, labels map[string]string, 
 	// mount the volume for the server standatalone data directory
 	volumeMounts = append(volumeMounts, corev1.VolumeMount{
 		Name:      standaloneDataVolumeName,
-		MountPath: resources.StandaloneServerDataDirPath,
+		MountPath: resources.JBossHome + "/" + resources.StandaloneServerDataDirRelativePath,
 	})
 
 	// mount the volume to read the standalone XML configuration from a ConfigMap

--- a/test/framework/wildlfyserver.go
+++ b/test/framework/wildlfyserver.go
@@ -87,7 +87,7 @@ func CreateAndWaitUntilReady(f *framework.Framework, ctx *framework.TestCtx, t *
 				namespacedName := types.NamespacedName{Name: name, Namespace: namespace}
 				if errPoll := f.Client.Get(context.TODO(), namespacedName, foundWildflyServer); errPoll != nil {
 					if apierrors.IsNotFound(errPoll) {
-						t.Logf("Cannot obtain object of the WildflyServer '%v' as it does not exist\n", name)
+						t.Logf("No WildFlyServer object '%v' to remove the finalizer at. Probably all cleanly finished before.\n", name)
 						return true, nil
 					}
 					t.Logf("Cannot obtain object of the WildflyServer '%v', cause: %v\n", name, errPoll)
@@ -249,7 +249,7 @@ func DeleteWildflyServer(context goctx.Context, wildflyServer *wildflyv1alpha1.W
 		_, err := f.KubeClient.AppsV1().StatefulSets(namespace).Get(name, metav1.GetOptions{IncludeUninitialized: true})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				t.Logf("Statefulset %s not found", name)
+				t.Logf("Statefulset %s was not found. It was probably successfully deleted already.", name)
 				return true, nil
 			}
 			t.Logf("Got error when getting statefulset %s: %s", name, err)


### PR DESCRIPTION
Adding a fix for transaction manager processing being disabled during the scaledown process - aka. no new transaction can be started.
The recovery of existing transaction is still possible (verified with EAP QE testsuite, cc @simkam)

This fix is expected to be follow-up with a broader service stoping during the recovery in future.

fixes #126 