### PR TITLE
updated README.adoc - replicas is a required spec

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -49,7 +49,7 @@ metadata:
   name: quickstart
 spec:
   applicationImage: "quay.io/wildfly-quickstarts/wildfly-operator-quickstart:18.0"
-  size: 2
+  replicas: 2
   storage:
     volumeClaimTemplate:
       spec:


### PR DESCRIPTION
as specified in the Custom Resource Definition

```
kind: CustomResourceDefinition
apiVersion: apiextensions.k8s.io/v1beta1
metadata:
  name: wildflyservers.wildfly.org
```

both `applicationImage` and `replicas` are required as specified here:

 ```
required:
        - applicationImage
        - replicas
```