### PR TITLE
[#126] fix on wrong boolean handling, disable transaction manager on scale down

### DIFF
--- a/pkg/controller/util/wildfly_mgmt.go
+++ b/pkg/controller/util/wildfly_mgmt.go
@@ -37,8 +37,8 @@ var (
 	MgmtOpSystemPropertyPeriodicRecoveryPeriod = "/system-property=com.arjuna.ats.arjuna.common.RecoveryEnvironmentBean.periodicRecoveryPeriod:add(value=%s)"
 	// MgmtOpSystemPropertyOrphanSafetyInterval is a JBoss CLI command to set system property of orphan safety interval
 	MgmtOpSystemPropertyOrphanSafetyInterval = "/system-property=com.arjuna.ats.jta.common.JTAEnvironmentBean.orphanSafetyInterval:add(value=%s)"
-	// MgmtOpSystemPropertyTransactionManagerEnabled is a JBoss CLI command to set system property to enable/disable transaction manager
-	MgmtOpSystemPropertyTransactionManagerEnabled = "/system-property=com.arjuna.ats.arjuna.common.CoordinatorEnvironmentBean.startDisabled:add(value=%s)"
+	// MgmtOpSystemPropertyTransactionManagerDisabled is a JBoss CLI command to set system property to disable/enable transaction manager
+	MgmtOpSystemPropertyTransactionManagerDisabled = "/system-property=com.arjuna.ats.arjuna.common.CoordinatorEnvironmentBean.startDisabled:add(value=%s)"
 )
 
 // IsMgmtOutcomeSuccesful verifies if the management operation was succcesfull

--- a/pkg/controller/wildflyserver/transaction_recovery.go
+++ b/pkg/controller/wildflyserver/transaction_recovery.go
@@ -172,7 +172,7 @@ func (r *ReconcileWildFlyServer) setupRecoveryPropertiesAndRestart(reqLogger log
 	if scaleDownPod.Annotations[markerRecoveryPropertiesSetup] == "" {
 		reqLogger.Info("Setting up back-off period and orphan detection properties for scaledown transaction recovery", "Pod Name", scaleDownPodName)
 		setPeriodOps := fmt.Sprintf(wildflyutil.MgmtOpSystemPropertyRecoveryBackoffPeriod, "1") + "," + fmt.Sprintf(wildflyutil.MgmtOpSystemPropertyOrphanSafetyInterval, "1")
-		disableTMOp := fmt.Sprintf(wildflyutil.MgmtOpSystemPropertyTransactionManagerEnabled, "false")
+		disableTMOp := fmt.Sprintf(wildflyutil.MgmtOpSystemPropertyTransactionManagerDisabled, "true")
 		jsonResult, errExecution := wildflyutil.ExecuteMgmtOp(scaleDownPod, setPeriodOps+","+disableTMOp)
 
 		// command may end-up with error with status 'rolled-back' which means duplication, thus do not check for error as error could be possitive outcome


### PR DESCRIPTION
fix for prior PR: https://github.com/wildfly/wildfly-operator/pull/127

I found I handled wrongly the boolean property as for disabling the transaction manager processing is needed to set to {{true}}.
The default is {{false}} - https://github.com/jbosstm/narayana/blob/5.10.4.Final/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/common/CoordinatorEnvironmentBean.java#L66