### PR TITLE
[#27] Support imagestream tag

### DIFF
--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -56,6 +56,9 @@ func NewStatefulSet(w *wildflyv1alpha1.WildFlyServer, labels map[string]string, 
 			Name:      w.Name,
 			Namespace: w.Namespace,
 			Labels:    labels,
+			Annotations: map[string]string{
+				"image.openshift.io/triggers": "[{ \"from\": { \"kind\":\"ImageStreamTag\", \"name\":\"" + w.Spec.ApplicationImage + "\"}, \"fieldPath\": \"spec.template.spec.containers[?(@.name==\\\"" + w.Name + "\\\")].image\"}]",
+			},
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas:            &replicas,


### PR DESCRIPTION
Add the image.openshift.io/triggers annotation to the stateful set so
that if an imagestream tag is used for the `applicationImage`, any
changes to the image will trigger a rolling upgrade of the statefulset.

This fixes #27

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>