### PR TITLE
Fix .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-openapi-gen
-operator-sdk
+./openapi-gen
+./operator-sdk
 
 # Temporary Build Files
 build/_output


### PR DESCRIPTION
only ignore binary files openapi-gen and operator-sdk at the root of the
project

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>