### PR TITLE
Skip setup target for test-e2e-prow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,12 @@ PROG  := wildfly-operator
 setup:
 	./build/setup-operator-sdk.sh
 
+## setup-e2e-test        Ensure the operator-sdk is installed for end-to-end tests.
+setup-e2e-test:
+	# Workaround for e2e test fails with additionalPrinterColumns in v1 CRDs https://github.com/operator-framework/operator-sdk/issues/3005,
+	# we need a operator v0.18.2 to run the e2e tests using CRD ApiVersion on apiextensions.k8s.io/v1
+	./build/setup-operator-sdk-e2e-tests.sh
+
 ## tidy                  Ensure modules are tidy.
 tidy:
 	go mod tidy
@@ -64,18 +70,17 @@ test: unit-test scorecard test-e2e
 test-e2e: test-e2e-17-local test-e2e-17-local
 
 ## test-e2e-17-local     Run e2e test for WildFly 17.0 with a local operator
-test-e2e-17-local: setup
-	LOCAL_OPERATOR=true JBOSS_HOME=/wildfly OPERATOR_NAME=wildfly-operator ./operator-sdk test local ./test/e2e/17.0 --verbose --debug  --operator-namespace default --up-local --local-operator-flags "--zap-devel --zap-level=5" --global-manifest ./deploy/crds/wildfly.org_wildflyservers_crd.yaml
+test-e2e-17-local: setup-e2e-test
+	LOCAL_OPERATOR=true JBOSS_HOME=/wildfly OPERATOR_NAME=wildfly-operator ./operator-sdk-e2e-tests test local ./test/e2e/17.0 --verbose --debug  --operator-namespace default --up-local --local-operator-flags "--zap-devel --zap-level=5" --global-manifest ./deploy/crds/wildfly.org_wildflyservers_crd.yaml
 
 ## test-e2e-18-local     Run e2e test for WildFly 18.0 with a local operator
-test-e2e-18-local: setup
-	LOCAL_OPERATOR=true JBOSS_HOME=/wildfly OPERATOR_NAME=wildfly-operator ./operator-sdk test local ./test/e2e/18.0 --verbose --debug  --operator-namespace default --up-local --local-operator-flags "--zap-devel --zap-level=5" --global-manifest ./deploy/crds/wildfly.org_wildflyservers_crd.yaml
+test-e2e-18-local: setup-e2e-test
+	LOCAL_OPERATOR=true JBOSS_HOME=/wildfly OPERATOR_NAME=wildfly-operator ./operator-sdk-e2e-tests test local ./test/e2e/18.0 --verbose --debug  --operator-namespace default --up-local --local-operator-flags "--zap-devel --zap-level=5" --global-manifest ./deploy/crds/wildfly.org_wildflyservers_crd.yaml
 
 ## test-e2e-18           Run e2e test for WildFly 18.0 with a containerized operator
-test-e2e-18: setup
+test-e2e-18: setup-e2e-test
 # Workaround for e2e test fails with additionalPrinterColumns in v1 CRDs https://github.com/operator-framework/operator-sdk/issues/3005,
 # we need a operator v0.18.2 to run the e2e tests using CRD ApiVersion on apiextensions.k8s.io/v1
-	./build/setup-operator-sdk-e2e-tests.sh
 	./operator-sdk-e2e-tests test local ./test/e2e/18.0 --verbose --debug
 
 ## test-e2e-prow         Run e2e test for WildFly 18.0 with a containerized operator in Prow (OpenShift CI)
@@ -83,10 +88,7 @@ test-e2e-18: setup
 ## and https://github.com/openshift/release/tree/master/ci-operator/jobs/wildfly/wildfly-operator
 test-e2e-prow: export component := wildfly-operator
 test-e2e-prow: export WILDFLY_OPERATOR_IMAGE := "${IMAGE_FORMAT}"
-test-e2e-prow: setup
-# Workaround for e2e test fails with additionalPrinterColumns in v1 CRDs https://github.com/operator-framework/operator-sdk/issues/3005,
-# we need a operator v0.18.2 to run the e2e tests using CRD ApiVersion on apiextensions.k8s.io/v1
-	./build/setup-operator-sdk-e2e-tests.sh
+test-e2e-prow: setup-e2e-test
 	./operator-sdk-e2e-tests test local ./test/e2e/18.0 --verbose --debug --image=$(WILDFLY_OPERATOR_IMAGE)
 
 ## scorecard             Run operator-sdk scorecard.


### PR DESCRIPTION
as it will use a specific setup-operator-sdk-e2e-tests.sh to set another
version of the operator-sdk specific for e2e tests

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>