### PR TITLE
[#168] Use ubi8-minimal:latest as the base image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+FROM registry.redhat.io/ubi8/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/wildfly-operator \
     JBOSS_HOME=/wildfly \


### PR DESCRIPTION
This fixes #168.

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>