### PR TITLE
Fix on sh scripts to not applying removed yaml files

### DIFF
--- a/build/run-minikube.sh
+++ b/build/run-minikube.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 
-kubectl apply -f deploy/service_account.yaml
-kubectl apply -f deploy/role.yaml
-kubectl apply -f deploy/role_binding.yaml
 # install WildFlyServer CRD
 kubectl apply -f deploy/crds/wildfly.org_wildflyservers_crd.yaml
-# install WildFly Operator
+# install WildFly Operator (plus service accounts and role binding)
 kubectl create -f deploy/operator.yaml

--- a/build/run-openshift.sh
+++ b/build/run-openshift.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
 oc adm policy add-cluster-role-to-user cluster-admin developer
-oc apply -f deploy/service_account.yaml
-oc apply -f deploy/role.yaml
-oc apply -f deploy/role_binding.yaml
 oc apply -f deploy/crds/wildfly.org_wildflyservers_crd.yaml
 oc apply -f deploy/operator.yaml


### PR DESCRIPTION
…where declaration was put under operator.yaml

As part of the commit for e2e tests for github some yaml declarations were moved under the `operator.yaml`. This should be reflected in the installation shell scripts.
https://github.com/wildfly/wildfly-operator/commit/ef0b424d05f9899e5e476367e2bd3c607c2ef173#diff-b7bd55c11b781b0ccc43aa6e57f9dadf0660e9d1d4e27e0979ee43a407d454ae