### PR TITLE
Build examples workflow

### DIFF
--- a/.github/workflows/build_examples.yml
+++ b/.github/workflows/build_examples.yml
@@ -1,0 +1,62 @@
+name: Wildfly Operator example images build
+
+on:
+  repository_dispatch:
+    types: [build_operator_examples]
+
+env:
+  LANG: en_US.UTF-8
+  S2I_URI: https://api.github.com/repos/openshift/source-to-image/releases/latest
+  QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+  QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+  EVENT_SOURCE: ${{ github.event.client_payload.source }}
+  EVENT_TYPE: ${{ github.event.action }}
+
+jobs:
+  build:
+    if: github.event.action == 'build_operator_examples'
+    name: Build Wildfly Operator examples
+    runs-on: ubuntu-latest
+    steps:
+    - name: Print info
+      run: echo "${EVENT_TYPE} received from ${EVENT_SOURCE}"
+    - name: Pull latest wildfly-s2i image
+      run: docker pull quay.io/wildfly/wildfly-centos7:latest
+    - name: Login quay.io
+      run: docker login -u="${QUAY_USERNAME}" -p="${QUAY_PASSWORD}" quay.io
+    - name: Install s2i binary
+      run: |
+        echo ===== Installing s2i from ${S2I_URI} =====
+        mkdir /tmp/s2i/ && cd /tmp/s2i/
+        curl -s ${S2I_URI} \
+         | grep browser_download_url \
+         | grep linux-amd64 \
+         | cut -d '"' -f 4 \
+         | wget -qi -
+         tar xvf source-to-image*.gz
+         sudo mv s2i /usr/bin
+         which s2i
+         s2i version
+    - name: Build PostgreSQL example and push to quay.io
+      run: |
+        s2i build https://github.com/wildfly/wildfly-s2i \
+        -e GALLEON_PROVISION_LAYERS=jaxrs-server,postgresql-datasource,observability \
+        -r master \
+        --context-dir test/test-app-postgres \
+        --loglevel=5 \
+        quay.io/wildfly/wildfly-centos7:latest \
+        wildfly-s2i-builder-image
+
+        docker tag wildfly-s2i-builder-image:latest quay.io/${QUAY_USERNAME}/taskrs-app:latest
+        docker push quay.io/${QUAY_USERNAME}/taskrs-app:latest
+    - name: Build Cluster Bench example and push to quay.io
+      run: |
+        s2i build https://github.com/clusterbench/clusterbench.git \
+        -e MAVEN_ARGS_APPEND=-Pee8 \
+        -e S2I_SOURCE_DEPLOYMENTS_DIR=clusterbench-ee8-ear/target \
+        -e GALLEON_PROVISION_LAYERS=cloud-server,web-clustering,ejb,-ejb-local-cache,ejb-dist-cache,jsf \
+        quay.io/wildfly/wildfly-centos7:latest \
+        wildfly-s2i-builder-image
+
+        docker tag wildfly-s2i-builder-image:latest quay.io/${QUAY_USERNAME}/clusterbench:latest
+        docker push quay.io/${QUAY_USERNAME}/clusterbench:latest

--- a/.github/workflows/build_examples.yml
+++ b/.github/workflows/build_examples.yml
@@ -7,8 +7,8 @@ on:
 env:
   LANG: en_US.UTF-8
   S2I_URI: https://api.github.com/repos/openshift/source-to-image/releases/latest
-  QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
-  QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+  QUAY_USERNAME: ${{ secrets.QUICKSTARTS_ROBOT_NAME }}
+  QUAY_PASSWORD: ${{ secrets.QUICKSTARTS_ROBOT_PASSWORD }}
   EVENT_SOURCE: ${{ github.event.client_payload.source }}
   EVENT_TYPE: ${{ github.event.action }}
 

--- a/build/build-examples.sh
+++ b/build/build-examples.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# this is the wildfly-operator repository user name. Useful if you want to trigger the event against your fork
+WILDFLY_OPERATOR_REPO_USER="${1:-wildfly}"
+
+if [ -z "${WILDFLY_OPERATOR_GITHUB_PAT}" ];
+then
+    echo
+    echo "Using this script requires the creation of a personal access token here: https://github.com/settings/tokens"
+    echo "The token should have the following permissions: repo:public_repo"
+    echo "Then export the token in your current shell: export WILDFLY_OPERATOR_GITHUB_PAT=... and re-run this script."
+    echo
+else
+    TARGET_REPO="https://api.github.com/repos/${WILDFLY_OPERATOR_REPO_USER}/wildfly-operator"
+    echo "Invoking building examples images workflow on ${TARGET_REPO}"
+    curl \
+    -X POST \
+    -H "Authorization: token ${WILDFLY_OPERATOR_GITHUB_PAT}" \
+    -H "Accept: application/vnd.github.ant-man-preview+json" \
+    -H "Content-Type: application/json" \
+    ${TARGET_REPO}/dispatches \
+    -d '{ "event_type" : "build_operator_examples", "client_payload" : { "source" : "wildfly-operator-make" }}'
+
+    result=$?
+    if [ "$result" != "0" ]; then
+       echo "the curl command failed with: $result"
+    else
+       echo "Done."
+    fi
+fi
+


### PR DESCRIPTION
A new GitHub action to build the application images used by the examples on GitHub with the latest wildfly-s2i image.

The idea is wildfly-s2 will trigger this event, I'm going to add a PR there to do so. Alternatively, we can invoke manually the workflow by invoking /build/build-examples.sh

To make this work the following secrets have to be created on this repo:
secrets.QUAY_USERNAME: The wildfly-quickstarts quay.io user name
secrets.QUAY_PASSWORD: The wildfly-quickstarts quay.io password

These secrets will define the user/pass to push the built application images.

We also need a new access token with the following permissions:
repo:public_repo

This token will be used by the wildfly-s2 workflow to dispatch the event against this repo when a new wildfly-s2i image is published in quay.io. See: https://github.com/wildfly/wildfly-s2i/pull/143

I'm going also to add a follow-up PR to clean up the examples a bit and make them use the:latest tag as application images.
