### PR TITLE
Allow autoscaling the operator with HPA

### DIFF
--- a/deploy/crds/quickstart-resources-cr.yaml
+++ b/deploy/crds/quickstart-resources-cr.yaml
@@ -1,0 +1,14 @@
+apiVersion: wildfly.org/v1alpha1
+kind: WildFlyServer
+metadata:
+  name: quickstart
+spec:
+  applicationImage: "quay.io/wildfly-quickstarts/wildfly-operator-quickstart:18.0"
+  replicas: 2
+  resources:
+    limits:
+      cpu: "1"
+      memory: "512Mi"
+    requests:
+      cpu: "500m"
+      memory: "256Mi"

--- a/deploy/crds/wildfly.org_wildflyservers_crd.yaml
+++ b/deploy/crds/wildfly.org_wildflyservers_crd.yaml
@@ -210,6 +210,33 @@ spec:
                 format: int32
                 minimum: 0
                 type: integer
+              resources:
+                description: 'Configuration of the resources used by the WildFlyServer,
+                  ie CPU and memory, use limits and requests More info: https://pkg.go.dev/k8s.io/api@v0.18.14/core/v1#ResourceRequirements'
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                type: object
               secrets:
                 description: Secrets is a list of Secrets in the same namespace as
                   the WildFlyServer object, which shall be mounted into the WildFlyServer

--- a/deploy/crds/wildfly.org_wildflyservers_crd.yaml
+++ b/deploy/crds/wildfly.org_wildflyservers_crd.yaml
@@ -561,15 +561,20 @@ spec:
                   \n Read-only."
                 format: int32
                 type: integer
+              selector:
+                description: selector for pods, used by HorizontalPodAutoscaler
+                type: string
             required:
             - replicas
             - scalingdownPods
+            - selector
             type: object
         type: object
     served: true
     storage: true
     subresources:
       scale:
+        labelSelectorPath: .status.selector
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}

--- a/pkg/apis/wildfly/v1alpha1/wildflyserver_types.go
+++ b/pkg/apis/wildfly/v1alpha1/wildflyserver_types.go
@@ -48,6 +48,9 @@ type WildFlyServerSpec struct {
 	// +kubebuilder:validation:MinItems=1
 	// +listType=set
 	ConfigMaps []string `json:"configMaps,omitempty"`
+	// Configuration of the resources used by the WildFlyServer, ie CPU and memory, use limits and requests
+	// More info: https://pkg.go.dev/k8s.io/api@v0.18.14/core/v1#ResourceRequirements
+	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 // StandaloneConfigMapSpec defines the desired configMap configuration to obtain the standalone configuration for WildFlyServer

--- a/pkg/apis/wildfly/v1alpha1/wildflyserver_types.go
+++ b/pkg/apis/wildfly/v1alpha1/wildflyserver_types.go
@@ -86,6 +86,8 @@ type WildFlyServerStatus struct {
 	//
 	// Read-only.
 	ScalingdownPods int32 `json:"scalingdownPods"`
+	// selector for pods, used by HorizontalPodAutoscaler
+	Selector string `json:"selector"`
 }
 
 const (
@@ -122,7 +124,7 @@ type PodStatus struct {
 // +k8s:openapi-gen=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
-// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 // +kubebuilder:printcolumn:name="Replicas",type="integer",JSONPath=".spec.replicas"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:shortName=wfly

--- a/pkg/apis/wildfly/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/wildfly/v1alpha1/zz_generated.deepcopy.go
@@ -161,6 +161,11 @@ func (in *WildFlyServerSpec) DeepCopyInto(out *WildFlyServerSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/apis/wildfly/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/wildfly/v1alpha1/zz_generated.openapi.go
@@ -13,12 +13,12 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"github.com/wildfly/wildfly-operator/pkg/apis/wildfly/v1alpha1.PodStatus":               schema_pkg_apis_wildfly_v1alpha1_PodStatus(ref),
-		"github.com/wildfly/wildfly-operator/pkg/apis/wildfly/v1alpha1.StandaloneConfigMapSpec": schema_pkg_apis_wildfly_v1alpha1_StandaloneConfigMapSpec(ref),
-		"github.com/wildfly/wildfly-operator/pkg/apis/wildfly/v1alpha1.StorageSpec":             schema_pkg_apis_wildfly_v1alpha1_StorageSpec(ref),
-		"github.com/wildfly/wildfly-operator/pkg/apis/wildfly/v1alpha1.WildFlyServer":           schema_pkg_apis_wildfly_v1alpha1_WildFlyServer(ref),
-		"github.com/wildfly/wildfly-operator/pkg/apis/wildfly/v1alpha1.WildFlyServerSpec":       schema_pkg_apis_wildfly_v1alpha1_WildFlyServerSpec(ref),
-		"github.com/wildfly/wildfly-operator/pkg/apis/wildfly/v1alpha1.WildFlyServerStatus":     schema_pkg_apis_wildfly_v1alpha1_WildFlyServerStatus(ref),
+		"./pkg/apis/wildfly/v1alpha1.PodStatus":               schema_pkg_apis_wildfly_v1alpha1_PodStatus(ref),
+		"./pkg/apis/wildfly/v1alpha1.StandaloneConfigMapSpec": schema_pkg_apis_wildfly_v1alpha1_StandaloneConfigMapSpec(ref),
+		"./pkg/apis/wildfly/v1alpha1.StorageSpec":             schema_pkg_apis_wildfly_v1alpha1_StorageSpec(ref),
+		"./pkg/apis/wildfly/v1alpha1.WildFlyServer":           schema_pkg_apis_wildfly_v1alpha1_WildFlyServer(ref),
+		"./pkg/apis/wildfly/v1alpha1.WildFlyServerSpec":       schema_pkg_apis_wildfly_v1alpha1_WildFlyServerSpec(ref),
+		"./pkg/apis/wildfly/v1alpha1.WildFlyServerStatus":     schema_pkg_apis_wildfly_v1alpha1_WildFlyServerStatus(ref),
 	}
 }
 
@@ -136,19 +136,19 @@ func schema_pkg_apis_wildfly_v1alpha1_WildFlyServer(ref common.ReferenceCallback
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/wildfly/wildfly-operator/pkg/apis/wildfly/v1alpha1.WildFlyServerSpec"),
+							Ref: ref("./pkg/apis/wildfly/v1alpha1.WildFlyServerSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/wildfly/wildfly-operator/pkg/apis/wildfly/v1alpha1.WildFlyServerStatus"),
+							Ref: ref("./pkg/apis/wildfly/v1alpha1.WildFlyServerStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/wildfly/wildfly-operator/pkg/apis/wildfly/v1alpha1.WildFlyServerSpec", "github.com/wildfly/wildfly-operator/pkg/apis/wildfly/v1alpha1.WildFlyServerStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"./pkg/apis/wildfly/v1alpha1.WildFlyServerSpec", "./pkg/apis/wildfly/v1alpha1.WildFlyServerStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -196,13 +196,13 @@ func schema_pkg_apis_wildfly_v1alpha1_WildFlyServerSpec(ref common.ReferenceCall
 					},
 					"standaloneConfigMap": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/wildfly/wildfly-operator/pkg/apis/wildfly/v1alpha1.StandaloneConfigMapSpec"),
+							Ref: ref("./pkg/apis/wildfly/v1alpha1.StandaloneConfigMapSpec"),
 						},
 					},
 					"storage": {
 						SchemaProps: spec.SchemaProps{
 							Description: "StorageSpec defines specific storage required for the server own data directory. If omitted, an EmptyDir is used (that will not persist data across pod restart).",
-							Ref:         ref("github.com/wildfly/wildfly-operator/pkg/apis/wildfly/v1alpha1.StorageSpec"),
+							Ref:         ref("./pkg/apis/wildfly/v1alpha1.StorageSpec"),
 						},
 					},
 					"serviceAccountName": {
@@ -285,12 +285,18 @@ func schema_pkg_apis_wildfly_v1alpha1_WildFlyServerSpec(ref common.ReferenceCall
 							},
 						},
 					},
+					"resources": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Configuration of the resources used by the WildFlyServer, ie CPU and memory, use limits and requests More info: https://pkg.go.dev/k8s.io/api@v0.18.14/core/v1#ResourceRequirements",
+							Ref:         ref("k8s.io/api/core/v1.ResourceRequirements"),
+						},
+					},
 				},
 				Required: []string{"applicationImage", "replicas"},
 			},
 		},
 		Dependencies: []string{
-			"github.com/wildfly/wildfly-operator/pkg/apis/wildfly/v1alpha1.StandaloneConfigMapSpec", "github.com/wildfly/wildfly-operator/pkg/apis/wildfly/v1alpha1.StorageSpec", "k8s.io/api/core/v1.EnvFromSource", "k8s.io/api/core/v1.EnvVar"},
+			"./pkg/apis/wildfly/v1alpha1.StandaloneConfigMapSpec", "./pkg/apis/wildfly/v1alpha1.StorageSpec", "k8s.io/api/core/v1.EnvFromSource", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements"},
 	}
 }
 
@@ -319,7 +325,7 @@ func schema_pkg_apis_wildfly_v1alpha1_WildFlyServerStatus(ref common.ReferenceCa
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/wildfly/wildfly-operator/pkg/apis/wildfly/v1alpha1.PodStatus"),
+										Ref: ref("./pkg/apis/wildfly/v1alpha1.PodStatus"),
 									},
 								},
 							},
@@ -355,6 +361,6 @@ func schema_pkg_apis_wildfly_v1alpha1_WildFlyServerStatus(ref common.ReferenceCa
 			},
 		},
 		Dependencies: []string{
-			"github.com/wildfly/wildfly-operator/pkg/apis/wildfly/v1alpha1.PodStatus"},
+			"./pkg/apis/wildfly/v1alpha1.PodStatus"},
 	}
 }

--- a/pkg/apis/wildfly/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/wildfly/v1alpha1/zz_generated.openapi.go
@@ -356,8 +356,15 @@ func schema_pkg_apis_wildfly_v1alpha1_WildFlyServerStatus(ref common.ReferenceCa
 							Format:      "int32",
 						},
 					},
+					"selector": {
+						SchemaProps: spec.SchemaProps{
+							Description: "selector for pods, used by HorizontalPodAutoscaler",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
-				Required: []string{"replicas", "scalingdownPods"},
+				Required: []string{"replicas", "scalingdownPods", "selector"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/controller/wildflyserver/wildflyserver_controller.go
+++ b/pkg/controller/wildflyserver/wildflyserver_controller.go
@@ -145,6 +145,9 @@ func (r *ReconcileWildFlyServer) Reconcile(request reconcile.Request) (reconcile
 		return r.manageError(wildflyServer, err)
 	}
 
+	// Set the selector label, this should be done for the pods as well to allow targeting the CR with HPA
+	wildflyServer.Status.Selector = fmt.Sprintf("app.kubernetes.io/instance=wildfly-%s", wildflyServer.GetName())
+
 	// If statefulset was deleted during processing recovery scaledown the number of replicas in WildflyServer spec
 	//  does not defines the number of pods which should be left active until recovered
 	desiredReplicaSizeForNewStatefulSet := wildflyServer.Spec.Replicas + wildflyServer.Status.ScalingdownPods
@@ -539,6 +542,7 @@ func LabelsForWildFly(w *wildflyv1alpha1.WildFlyServer) map[string]string {
 	labels["app.kubernetes.io/name"] = w.Name
 	labels["app.kubernetes.io/managed-by"] = os.Getenv("LABEL_APP_MANAGED_BY")
 	labels["app.openshift.io/runtime"] = os.Getenv("LABEL_APP_RUNTIME")
+	labels["app.kubernetes.io/instance"] = fmt.Sprintf("wildfly-%s", w.GetName())
 	if w.Labels != nil {
 		for labelKey, labelValue := range w.Labels {
 			labels[labelKey] = labelValue

--- a/pkg/controller/wildflyserver/wildflyserver_controller_test.go
+++ b/pkg/controller/wildflyserver/wildflyserver_controller_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/wildfly/wildfly-operator/pkg/resources/services"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	testifyAssert "github.com/stretchr/testify/assert"
@@ -405,4 +406,74 @@ func TestWildFlyServerWithConfigMap(t *testing.T) {
 		}
 	}
 	assert.True(foundVolumeMount)
+}
+
+func TestWildFlyServerWithResources(t *testing.T) {
+	// Set the logger to development mode for verbose logs.
+	logf.SetLogger(zap.Logger())
+	assert := testifyAssert.New(t)
+
+	var (
+		requestCpu = resource.MustParse("250m")
+		requestMem = resource.MustParse("128Mi")
+		limitCpu   = resource.MustParse("1")
+		limitMem   = resource.MustParse("512Mi")
+	)
+
+	// A WildFlyServer resource with metadata and spec.
+	wildflyServer := &wildflyv1alpha1.WildFlyServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: wildflyv1alpha1.WildFlyServerSpec{
+			ApplicationImage: applicationImage,
+			Replicas:         replicas,
+			Resources: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    requestCpu,
+					corev1.ResourceMemory: requestMem,
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    limitCpu,
+					corev1.ResourceMemory: limitMem,
+				},
+			},
+		},
+	}
+	// Objects to track in the fake client.
+	objs := []runtime.Object{
+		wildflyServer,
+	}
+
+	// Register operator types with the runtime scheme.
+	s := scheme.Scheme
+	s.AddKnownTypes(wildflyv1alpha1.SchemeGroupVersion, wildflyServer)
+	// Create a fake client to mock API calls.
+	cl := fake.NewFakeClient(objs...)
+	// Create a ReconcileWildFlyServer object with the scheme and fake client.
+	r := &ReconcileWildFlyServer{client: cl, scheme: s}
+
+	// Mock request to simulate Reconcile() being called on an event for a
+	// watched resource .
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	// statefulset will be created
+	_, err := r.Reconcile(req)
+	require.NoError(t, err)
+
+	// Check if stateful set has been created with the correct configuration.
+	statefulSet := &appsv1.StatefulSet{}
+	err = cl.Get(context.TODO(), req.NamespacedName, statefulSet)
+	require.NoError(t, err)
+	assert.Equal(replicas, *statefulSet.Spec.Replicas)
+	assert.Equal(applicationImage, statefulSet.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(requestCpu, statefulSet.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU])
+	assert.Equal(requestMem, statefulSet.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory])
+	assert.Equal(limitCpu, statefulSet.Spec.Template.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU])
+	assert.Equal(limitMem, statefulSet.Spec.Template.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory])
 }

--- a/pkg/controller/wildflyserver/wildflyserver_controller_test.go
+++ b/pkg/controller/wildflyserver/wildflyserver_controller_test.go
@@ -477,3 +477,52 @@ func TestWildFlyServerWithResources(t *testing.T) {
 	assert.Equal(limitCpu, statefulSet.Spec.Template.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU])
 	assert.Equal(limitMem, statefulSet.Spec.Template.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory])
 }
+
+func TestWildFlyServerSelectorLabel(t *testing.T) {
+	// Set the loggclearer to development mode for verbose logs.
+	logf.SetLogger(zap.Logger())
+	assert := testifyAssert.New(t)
+
+	// A WildFlyServer resource with metadata and spec.
+	wildflyServer := &wildflyv1alpha1.WildFlyServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: wildflyv1alpha1.WildFlyServerSpec{
+			ApplicationImage: applicationImage,
+			Replicas:         replicas,
+			SessionAffinity:  sessionAffinity,
+		},
+	}
+	// Objects to track in the fake client.
+	objs := []runtime.Object{
+		wildflyServer,
+	}
+
+	// Register operator types with the runtime scheme.
+	s := scheme.Scheme
+	s.AddKnownTypes(wildflyv1alpha1.SchemeGroupVersion, wildflyServer)
+	// Create a fake client to mock API calls.
+	cl := fake.NewFakeClient(objs...)
+	// Create a ReconcileWildFlyServer object with the scheme and fake client.
+	r := &ReconcileWildFlyServer{client: cl, scheme: s}
+
+	// Mock request to simulate Reconcile() being called on an event for a
+	// watched resource .
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	// statefulset will be created
+	_, err := r.Reconcile(req)
+	require.NoError(t, err)
+
+	// Verify statefull set template selector label.
+	statefulSet := &appsv1.StatefulSet{}
+	err = cl.Get(context.TODO(), req.NamespacedName, statefulSet)
+	require.NoError(t, err)
+	assert.Contains(statefulSet.Spec.Template.GetLabels()["app.kubernetes.io/instance"], "wildfly-myapp")
+}

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -107,6 +107,11 @@ func NewStatefulSet(w *wildflyv1alpha1.WildFlyServer, labels map[string]string, 
 		},
 	}
 
+	// if the user specified the resources directive propagate it to the container (required for HPA).
+	if w.Spec.Resources != nil {
+		statefulSet.Spec.Template.Spec.Containers[0].Resources = *w.Spec.Resources
+	}
+
 	if len(w.Spec.EnvFrom) > 0 {
 		statefulSet.Spec.Template.Spec.Containers[0].EnvFrom = append(statefulSet.Spec.Template.Spec.Containers[0].EnvFrom, w.Spec.EnvFrom...)
 	}

--- a/test/framework/wildlfyserver.go
+++ b/test/framework/wildlfyserver.go
@@ -5,11 +5,12 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"regexp"
 	"strings"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
**Added a [Resources](https://pkg.go.dev/k8s.io/api@v0.18.14/core/v1#ResourceRequirements) field to the `WildFlyServerSpec` type.**

This will allow the user to specify the CPU requirement for containers,
which is mandatory for the HPA calculation of CPU utilization.

Example of HPA eligible application:

```yaml
apiVersion: wildfly.org/v1alpha1
kind: WildFlyServer
metadata:
  name: quickstart
spec:
  applicationImage: "quay.io/wildfly-quickstarts/wildfly-operator-quickstart:18.0"
  replicas: 2
  resources:
    requests:
      cpu: "0.5"
```

---------------------------------------------------

**Added a string `Selector` field of type string to the `WildFlyServerStatus` type.**

This will be used for storing the selector label which is populated by the operator with the key [app.kubernetes.io/instance](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels).
The value for the label is created from the prefix `wildfly-` concatenated with the application name.
The same label is also applied to the underlying containers via the StatefulSet's template.

This is required for targeting the CR with the HPA instead of the underlying StatefulSet,
which is required to maintain the CR as the source for any of its resources.