### PR TITLE
[#213] Create the service as a ClusterIP

### DIFF
--- a/pkg/controller/wildflyserver/wildflyserver_controller.go
+++ b/pkg/controller/wildflyserver/wildflyserver_controller.go
@@ -207,11 +207,11 @@ func (r *ReconcileWildFlyServer) Reconcile(request reconcile.Request) (reconcile
 		return reconcile.Result{}, err
 	}
 
-	// Check if the loadbalancer already exists, if not create a new one
-	loadBalancer, err := services.CreateOrUpdateLoadBalancerService(wildflyServer, r.client, r.scheme, LabelsForWildFly(wildflyServer))
+	// Check if the cluster service already exists, if not create a new one
+	clusterService, err := services.CreateOrUpdateClusterService(wildflyServer, r.client, r.scheme, LabelsForWildFly(wildflyServer))
 	if err != nil {
 		return reconcile.Result{}, err
-	} else if loadBalancer == nil {
+	} else if clusterService == nil {
 		return reconcile.Result{Requeue: true}, nil
 	}
 	// Check if the headless service already exists, if not create a new one

--- a/pkg/controller/wildflyserver/wildflyserver_controller_test.go
+++ b/pkg/controller/wildflyserver/wildflyserver_controller_test.go
@@ -80,14 +80,14 @@ func TestWildFlyServerControllerCreatesStatefulSet(t *testing.T) {
 	assert.Equal(replicas, *statefulSet.Spec.Replicas)
 	assert.Equal(applicationImage, statefulSet.Spec.Template.Spec.Containers[0].Image)
 
-	// loadbalancer service will be created
+	// cluster service will be created
 	_, err = r.Reconcile(req)
 	require.NoError(t, err)
 
-	loadbalancer := &corev1.Service{}
-	err = cl.Get(context.TODO(), types.NamespacedName{Name: services.LoadBalancerServiceName(wildflyServer), Namespace: req.Namespace}, loadbalancer)
+	clusterService := &corev1.Service{}
+	err = cl.Get(context.TODO(), types.NamespacedName{Name: services.ClusterServiceName(wildflyServer), Namespace: req.Namespace}, clusterService)
 	require.NoError(t, err)
-	assert.Equal(corev1.ServiceAffinityClientIP, loadbalancer.Spec.SessionAffinity)
+	assert.Equal(corev1.ServiceAffinityClientIP, clusterService.Spec.SessionAffinity)
 
 	// headless service will be created
 	_, err = r.Reconcile(req)

--- a/pkg/resources/routes/route.go
+++ b/pkg/resources/routes/route.go
@@ -63,7 +63,7 @@ func newRoute(w *wildflyv1alpha1.WildFlyServer, labels map[string]string) *route
 		Spec: routev1.RouteSpec{
 			To: routev1.RouteTargetReference{
 				Kind:   "Service",
-				Name:   services.LoadBalancerServiceName(w),
+				Name:   services.ClusterServiceName(w),
 				Weight: &weight,
 			},
 			Port: &routev1.RoutePort{


### PR DESCRIPTION
The service used to access the statefulset pods is a ClusterIP service
and no longer a LoadBalancer service.

It renamed named with the "-loadbalancer" suffix for backwards
compatibility.

This fixes #213

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>