### PR TITLE
[#221] Do not require .status.selector field

### DIFF
--- a/deploy/crds/wildfly.org_wildflyservers_crd.yaml
+++ b/deploy/crds/wildfly.org_wildflyservers_crd.yaml
@@ -567,7 +567,6 @@ spec:
             required:
             - replicas
             - scalingdownPods
-            - selector
             type: object
         type: object
     served: true

--- a/pkg/apis/wildfly/v1alpha1/wildflyserver_types.go
+++ b/pkg/apis/wildfly/v1alpha1/wildflyserver_types.go
@@ -87,7 +87,7 @@ type WildFlyServerStatus struct {
 	// Read-only.
 	ScalingdownPods int32 `json:"scalingdownPods"`
 	// selector for pods, used by HorizontalPodAutoscaler
-	Selector string `json:"selector"`
+	Selector string `json:"selector,omitempty"`
 }
 
 const (

--- a/version/version.go
+++ b/version/version.go
@@ -2,5 +2,5 @@ package version
 
 var (
 	// Version represents the software version of the WildFly Operator
-	Version = "0.5.3"
+	Version = "0.5.4"
 )


### PR DESCRIPTION
Making this field required prevents to update the Operator with OLM when
there are existing WildFlyServer CR on the cluster.

This change does not impact HPA as this field will be set by the
operator when it manages the WildFlyServer CR

This fixes #221

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>