### PR TITLE
[0.5.x][issue-242] Build and publish an image for main and 0.5.x when…

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.13
+        go-version: 1.17.7
     - name: Build
       run: make build
     - name: Set up Minikube
@@ -31,14 +31,16 @@ jobs:
         driver: docker
     - name: Containerized End-to-End Tests
       run: eval $(minikube -p minikube docker-env) && make test-e2e-minikube
-    - name: Docker Login to Quay.io (main only)
+    - name: Docker Login to Quay.io (main and 0.5.x only)
       uses: docker/login-action@v1.8.0
-      if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/0.5.x'
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ env.REGISTRY_USER }}
         password: ${{ env.REGISTRY_PASSWORD }}
-    - name: Build and Push Image (main only)
+    - name: Build and Push Image (main)
       if: github.ref == 'refs/heads/main'
-      run: make push
-
+      run: IMG=quay.io/${{ env.REGISTRY_USER }}/wildfly-operator:latest make manifests docker-build docker-push
+    - name: Build and Push Image (0.5.x)
+      if: github.ref == 'refs/heads/0.5.x'
+      run: TAG=0.5.x IMAGE=wildfly-operator DOCKER_REPO=quay.io/${{ env.REGISTRY_USER }}/ make push


### PR DESCRIPTION
… PRs get merged

Backports #247

@jmesnil This is important for QE so they can have a specific tag for 0.5.x merged PRs.