### PR TITLE
[#266] Updated Pod security standards

### DIFF
--- a/api/v1alpha1/wildflyserver_types.go
+++ b/api/v1alpha1/wildflyserver_types.go
@@ -68,6 +68,8 @@ type WildFlyServerSpec struct {
 	// More info: https://pkg.go.dev/k8s.io/api@v0.18.14/core/v1#ResourceRequirements
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 	// SecurityContext
+	// If omitted, a default security context is created to deploy the application in non-root user without priviledges
+	// escalation and all security capabilities dropped.
 	SecurityContext *corev1.SecurityContext `json:"securityContext,omitempty"`
 }
 

--- a/bundle/manifests/wildfly-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/wildfly-operator.clusterserviceversion.yaml
@@ -95,7 +95,14 @@ spec:
                   requests:
                     cpu: 100m
                     memory: 20Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                      - ALL
               serviceAccountName: wildfly-operator
+              securityContext:
+                runAsNonRoot: true
               terminationGracePeriodSeconds: 10
       permissions:
       - rules:

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -56,6 +56,12 @@ func NewStatefulSet(w *wildflyv1alpha1.WildFlyServer, labels map[string]string, 
 		wildflyImageTypeAnnotation = resources.ImageTypeBootable
 	}
 
+	allowPrivilegeEscalation := new(bool)
+	*allowPrivilegeEscalation = false
+
+	runAsNonRoot := new(bool)
+	*runAsNonRoot = true
+
 	statefulSet := &appsv1.StatefulSet{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -119,6 +125,17 @@ func NewStatefulSet(w *wildflyv1alpha1.WildFlyServer, labels map[string]string, 
 	// if the user specified the securityContext directive propagate it to the container (required for HPA).
 	if w.Spec.SecurityContext != nil {
 		statefulSet.Spec.Template.Spec.Containers[0].SecurityContext = *&w.Spec.SecurityContext
+	} else {
+		// otherwise, use a default security context without any security priviledges
+		statefulSet.Spec.Template.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{
+			AllowPrivilegeEscalation: allowPrivilegeEscalation,
+			Capabilities:             &corev1.Capabilities{
+				Drop: []corev1.Capability{
+					"ALL",
+				},
+			},
+			RunAsNonRoot: runAsNonRoot,
+		}
 	}
 
 	if len(w.Spec.EnvFrom) > 0 {


### PR DESCRIPTION
* Add a default Security Context if the user does not specify one from the WildFlyServerSpec.
* In the CSV, updates the operator's own deployment to comply with the security standards.

This fixes #266