### PR TITLE
Load wildfly application images in Minikube

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,6 +29,11 @@ jobs:
         minikube version: v1.22.0
         kubernetes version: v1.20.0
         driver: docker
+    - name: Load WildFly images used for testing
+      run: |-
+        minikube image load --pull=true quay.io/wildfly-quickstarts/wildfly-operator-quickstart:18.0
+        minikube image load --pull=true quay.io/wildfly-quickstarts/wildfly-operator-quickstart:bootable-21.0
+        minikube image load --pull=true quay.io/wildfly-quickstarts/clusterbench:latest
     - name: Containerized End-to-End Tests
       run: eval $(minikube -p minikube docker-env) && make test-e2e-minikube
     - name: Docker Login to Quay.io (main only)

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ run-test-e2e:
 	$(KUSTOMIZE) build config/rbac | kubectl apply -f -
 	mkdir -p dry-run
 	$(KUSTOMIZE) build config/tests > dry-run/test-resources.yaml
-	LOCAL_MANAGER=0 go test -v ./test/e2e/... -coverprofile cover.out
+	LOCAL_MANAGER=0 go test -timeout 20m -v ./test/e2e/... -coverprofile cover.out
 	$(KUSTOMIZE) build config/rbac | kubectl delete --ignore-not-found=true -f -
 
 .PHONY: clean


### PR DESCRIPTION
to make the tests run faster as they will not have to pull the images