### PR TITLE
Fix release action and stick open-api gen to a specific version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,9 +21,13 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.21.3
       - name: Docker Login to Quay.io (main only)
-        uses: docker/login-action@v1.8.0
+        uses: docker/login-action@v3.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.REGISTRY_USER }}

--- a/Makefile
+++ b/Makefile
@@ -336,7 +336,7 @@ catalog-push: ## Push a catalog image.
 .PHONY: openapi-gen
 openapi-gen: $(OPENAPI_GEN) ## Download envtest-setup locally if necessary.
 $(OPENAPI_GEN): $(LOCALBIN)
-	test -s $(LOCALBIN)/openapi-gen || GOBIN=$(LOCALBIN) go install k8s.io/kube-openapi/cmd/openapi-gen@latest
+	test -s $(LOCALBIN)/openapi-gen || GOBIN=$(LOCALBIN) go install k8s.io/kube-openapi/cmd/openapi-gen@649db6989aaecdd64cc4ea16b76e0d0067664001
 
 .PHONY: dlv
 dlv: $(DLV) ## Download envtest-setup locally if necessary.


### PR DESCRIPTION
Fix the git hub release action according to the latest status and stick the openapi-gen to a specific commit where the shorthand arguments are still working