### PR TITLE
[#342] Prevent shell injection in RemoteOps.Execute

### DIFF
--- a/controllers/transaction_recovery.go
+++ b/controllers/transaction_recovery.go
@@ -184,7 +184,7 @@ func (r *WildFlyServerReconciler) checkRecovery(reqLogger logr.Logger, scaleDown
 		return recovery, retString, nil
 	}
 	// Verification of the unfinished data of the WildFly transaction client (verification of the directory content)
-	lsCommand := fmt.Sprintf(`ls ${JBOSS_HOME}/%s/%s/ 2> /dev/null || true`, resources.StandaloneServerDataDirRelativePath, wftcDataDirName)
+	lsCommand := []string{"/bin/sh", "-c", fmt.Sprintf(`ls ${JBOSS_HOME}/%s/%s/ 2> /dev/null || true`, resources.StandaloneServerDataDirRelativePath, wftcDataDirName)}
 	commandResult, err := wfly.RemoteOps.Execute(scaleDownPod, lsCommand)
 	if err != nil {
 		return genericError, "", fmt.Errorf("Cannot query the filesystem of the pod %v to check existing remote transactions. "+
@@ -234,7 +234,7 @@ func (r *WildFlyServerReconciler) setupRecoveryPropertiesAndRestart(reqLogger lo
 		}
 
 		reqLogger.Info("Setting system property 'org.wildfly.internal.cli.boot.hook.marker.dir' at '/tmp/markerdir/wf-cli-shutdown-initiated'", "Pod Name", scaleDownPodName)
-		wfly.RemoteOps.Execute(scaleDownPod, "mkdir /tmp/markerdir && touch /tmp/markerdir/wf-cli-shutdown-initiated || true")
+		wfly.RemoteOps.Execute(scaleDownPod, []string{"/bin/sh", "-c", "mkdir /tmp/markerdir && touch /tmp/markerdir/wf-cli-shutdown-initiated || true"})
 		wfly.ExecuteMgmtOp(scaleDownPod, "/system-property=org.wildfly.internal.cli.boot.hook.marker.dir:add(value=/tmp/markerdir)")
 
 		reqLogger.Info("Restarting application server to apply the env properties", "Pod Name", scaleDownPodName)

--- a/controllers/transaction_recovery_test.go
+++ b/controllers/transaction_recovery_test.go
@@ -399,19 +399,20 @@ type remoteOpsMock struct {
 	ExecuteMockReturn [][]string
 }
 
-func (rops *remoteOpsMock) Execute(pod *corev1.Pod, command string) (string, error) {
+func (rops *remoteOpsMock) Execute(pod *corev1.Pod, command []string) (string, error) {
 	stringToReturn := ""
+	commandStr := strings.Join(command, " ")
 	if len(rops.ExecuteMockReturn) > 0 {
 		stringToReturn = rops.ExecuteMockReturn[0][0]
 		if len(rops.ExecuteMockReturn[0]) > 1 {
 			stringToVerify := rops.ExecuteMockReturn[0][1]
-			if !strings.Contains(command, stringToVerify) {
-				panic(fmt.Sprintf("The command string '%v' does not contain required string '%v'", command, stringToVerify))
+			if !strings.Contains(commandStr, stringToVerify) {
+				panic(fmt.Sprintf("The command string '%v' does not contain required string '%v'", commandStr, stringToVerify))
 			}
 		}
 		rops.ExecuteMockReturn = rops.ExecuteMockReturn[1:] // dequeuing, removal of the first item
 	}
-	ctrl.Log.Info("remoteOpsMock.Execute command:'" + command + "',  returns: '" + stringToReturn + "'")
+	ctrl.Log.Info("remoteOpsMock.Execute command:'" + commandStr + "',  returns: '" + stringToReturn + "'")
 	return stringToReturn, nil
 }
 func (rops remoteOpsMock) SocketConnect(hostname string, port int32, command string) (string, error) {

--- a/pkg/util/remote_ops.go
+++ b/pkg/util/remote_ops.go
@@ -35,7 +35,7 @@ var (
 )
 
 type RemoteOperationsInterface interface {
-	Execute(pod *corev1.Pod, command string) (string, error)
+	Execute(pod *corev1.Pod, command []string) (string, error)
 	SocketConnect(hostname string, port int32, command string) (string, error)
 	VerifyLogContainsRegexp(pod *corev1.Pod, logFromTime *time.Time, regexpLineCheck *regexp.Regexp) (string, error)
 	ObtainLogLatestTimestamp(pod *corev1.Pod) (*time.Time, error)
@@ -49,7 +49,7 @@ func init() {
 }
 
 // Execute executes a command inside the remote pod
-func (RemoteOperationsStruct) Execute(pod *corev1.Pod, command string) (string, error) {
+func (RemoteOperationsStruct) Execute(pod *corev1.Pod, command []string) (string, error) {
 	var (
 		execOut bytes.Buffer
 		execErr bytes.Buffer
@@ -79,7 +79,7 @@ func (RemoteOperationsStruct) Execute(pod *corev1.Pod, command string) (string, 
 		SubResource("exec").
 		VersionedParams(&corev1.PodExecOptions{
 			Container: pod.Spec.Containers[0].Name,
-			Command:   []string{"/bin/sh", "-c", command},
+			Command:   command,
 			// Stdin:     true,
 			Stdout: true,
 			Stderr: true,

--- a/pkg/util/wildfly_mgmt.go
+++ b/pkg/util/wildfly_mgmt.go
@@ -58,7 +58,8 @@ func IsMgmtOutcomeSuccesful(jsonBody map[string]interface{}) bool {
 //	the execution runs as shh remote command with jboss-cli.sh executed on the pod
 //	returns the JSON as the return value from the operation
 func ExecuteMgmtOp(pod *corev1.Pod, mgmtOpString string) (map[string]interface{}, error) {
-	jbossCliCommand := fmt.Sprintf("${JBOSS_HOME}/bin/jboss-cli.sh --output-json -c --commands='%s'", mgmtOpString)
+	// Use positional argument for the mgmtOpString so that it isn't parsed for shell metacharacters (such a single quote, backticks, etc.)
+	jbossCliCommand := []string{"/bin/sh", "-c", `$JBOSS_HOME/bin/jboss-cli.sh --output-json -c "--commands=$1"`, "_", mgmtOpString}
 	resString, err := RemoteOps.Execute(pod, jbossCliCommand)
 	if err != nil && resString == "" {
 		return nil, fmt.Errorf("Cannot execute JBoss CLI command %s at pod %v. Cause: %v", jbossCliCommand, pod.Name, err)


### PR DESCRIPTION
Change Execute command parameter from string to []string so the command is passed directly to PodExecOptions without implicit shell wrapping. Callers that need shell features (env var expansion, redirects, logical operators) now explicitly use /bin/sh -c with positional parameters to keep untrusted input out of the shell command string.

Fixes #342